### PR TITLE
Fix for international(non-Latin) build environment

### DIFF
--- a/gameplay/src/Bundle.cpp
+++ b/gameplay/src/Bundle.cpp
@@ -182,7 +182,7 @@ Bundle* Bundle::create(const char* path)
 
     // Read the GPB header info.
     char sig[9];
-    if (fread(sig, 1, 9, fp) != 9 || memcmp(sig, "«GPB»\r\n\x1A\n", 9) != 0)
+    if (fread(sig, 1, 9, fp) != 9 || memcmp(sig, "\xABGPB\xBB\r\n\x1A\n", 9) != 0)
     {
         GP_ERROR("Invalid GPB header for bundle '%s'.", path);
         if (fclose(fp) != 0)


### PR DESCRIPTION
In the non-Latin code page environment, such as the Korean code page, the extended ASCII characters are not representable or translated into a fallback character like "?" in IDE or editors. When these files are compiled and running, it crashes with the error "Invalid GPB header for bundle ...".
