### PR TITLE
Fixes bug where ACTIVE controls stop receiving Touch::TOUCH_MOVE events when the cursor is no longer over the control.

### DIFF
--- a/gameplay-samples/sample03-character/src/CharacterGame.h
+++ b/gameplay-samples/sample03-character/src/CharacterGame.h
@@ -101,14 +101,12 @@ private:
     unsigned int _keyFlags;
     int _drawDebug;
     bool _wireframe;
-    
-    bool* _buttonPressed;
-    Gamepad* _gamepad;
-    Vector2 _currentDirection;
-    
     Vector3 _oldBallPosition;
     bool _hasBall;
     bool _applyKick;
+    bool* _buttonPressed;
+    Gamepad* _gamepad;
+    Vector2 _currentDirection;
 
 };
 

--- a/gameplay/src/Container.h
+++ b/gameplay/src/Container.h
@@ -504,6 +504,8 @@ private:
 
     float _totalWidth;
     float _totalHeight;
+
+    int _contactIndices;
 };
 
 }


### PR DESCRIPTION
Fixes bug where ACTIVE controls stop receiving Touch::TOUCH_MOVE events when the cursor is no longer over the control.

Cleans up code in sample03-character.
