### PR TITLE
Fixes bug in Button control where touchEvent() was returning false when handling Touch::TOUCH_RELEASE events instead of _consumeInputEvents.

### DIFF
--- a/gameplay-samples/sample03-character/res/common/gamepad.form
+++ b/gameplay-samples/sample03-character/res/common/gamepad.form
@@ -34,7 +34,6 @@ form gamepadForm
             button
             {
                 style = buttonAStyle
-                consumeEvents = false
                 size = 128, 128
                 alignment = ALIGN_BOTTOM_LEFT
             }
@@ -42,7 +41,6 @@ form gamepadForm
             button
             {
                 style = buttonBStyle
-                consumeEvents = false
                 size = 128, 128
                 alignment = ALIGN_TOP_RIGHT
             }

--- a/gameplay/src/Button.cpp
+++ b/gameplay/src/Button.cpp
@@ -64,14 +64,12 @@ bool Button::touchEvent(Touch::TouchEvent evt, int x, int y, unsigned int contac
             setState(Control::FOCUS);
 
             notifyListeners(Listener::CLICK);
-
-            return _consumeInputEvents;
         }
         else
         {
             setState(Control::NORMAL);
         }
-        break;
+        return _consumeInputEvents;
 
     case Touch::TOUCH_MOVE:
         return _consumeInputEvents;


### PR DESCRIPTION
Fixes bug in Button control where touchEvent() was returning false when handling Touch::TOUCH_RELEASE events instead of _consumeInputEvents.
