### PR TITLE
Fixes #286 missing slash for new projects that are not under GamePlay.

### DIFF
--- a/gameplay-newproject.sh
+++ b/gameplay-newproject.sh
@@ -151,7 +151,7 @@ while [ "${gpPathAbs#$common_path}" = "${gpPathAbs}" ]; do
 		back="../${back}"
 	fi
 done
-gpPath=${back}${gpPathAbs#$common_path/}
+gpPath=${back}/${gpPathAbs#$common_path/}
 if [[ ${gpPathAbs} == ${common_path} ]]; then
 	gpPath=${back}
 fi


### PR DESCRIPTION
Tested fixed for a new project not under GamePlay, specified both relative and absolute. Tested no regression for a new project that is under GamePlay.
