### PR TITLE
Reverts to standard precision heightmap as the default

### DIFF
--- a/gameplay-encoder/src/EncoderArguments.cpp
+++ b/gameplay-encoder/src/EncoderArguments.cpp
@@ -18,7 +18,8 @@ EncoderArguments::EncoderArguments(size_t argc, const char** argv) :
     _parseError(false),
     _fontPreview(false),
     _textOutput(false),
-    _daeOutput(false)
+    _daeOutput(false),
+    _isHeightmapHighP(false)
 {
     __instance = this;
 
@@ -150,6 +151,11 @@ const std::vector<std::string>& EncoderArguments::getHeightmapNodeIds() const
     return _heightmapNodeIds;
 }
 
+bool EncoderArguments::isHeightmapHighP() const
+{
+    return _isHeightmapHighP;
+}
+
 bool EncoderArguments::parseErrorOccured() const
 {
     return _parseError;
@@ -184,7 +190,8 @@ void EncoderArguments::printUsage() const
     fprintf(stderr,"  -h \"<node ids>\"\n" \
         "\t\t\tList of nodes to generate heightmaps for.\n" \
         "\t\t\tNode id list should be in quotes with a space between each id.\n" \
-        "\t\t\tHeightmaps will be saved in files named <nodeid>.png.\n");
+        "\t\t\tHeightmaps will be saved in files named <nodeid>.png.\n" \
+        "\t\t\tFor 24-bit packed height data use -hp instead of -h.\n");
     fprintf(stderr,"\n");
     fprintf(stderr,"TTF file options:\n");
     fprintf(stderr,"  -s <size of font>\tSize of the font.\n");
@@ -313,8 +320,10 @@ void EncoderArguments::readOption(const std::vector<std::string>& options, size_
         break;
     case 'h':
         {
-            if (str.compare("-heightmaps") == 0 || str.compare("-h") == 0)
+            bool isHighPrecision = str.compare("-hp") == 0;
+            if (str.compare("-heightmaps") == 0 || str.compare("-h") == 0 || isHighPrecision)
             {
+                _isHeightmapHighP = isHighPrecision;
                 (*index)++;
                 if (*index < options.size())
                 {

--- a/gameplay-encoder/src/EncoderArguments.h
+++ b/gameplay-encoder/src/EncoderArguments.h
@@ -74,6 +74,11 @@ public:
     const std::string getAnimationId(const std::string& nodeId) const;
 
     const std::vector<std::string>& getHeightmapNodeIds() const;
+    
+    /**
+     * Returns true if the heightmap is to be high precision (24-bit packed).
+     */
+    bool isHeightmapHighP() const;
 
     /**
      * Returns true if an error occurred while parsing the command line arguments.
@@ -139,6 +144,7 @@ private:
     bool _fontPreview;
     bool _textOutput;
     bool _daeOutput;
+    bool _isHeightmapHighP;
 
     std::vector<std::string> _groupAnimationNodeId;
     std::vector<std::string> _groupAnimationAnimationId;

--- a/gameplay-encoder/src/Mesh.cpp
+++ b/gameplay-encoder/src/Mesh.cpp
@@ -139,7 +139,7 @@ bool intersect(const Vector3& rayOrigin, const Vector3& rayDirection, const std:
     return false;
 }
 
-void Mesh::generateHeightmap(const char* filename)
+void Mesh::generateHeightmap(const char* filename, bool highP)
 {
     // Shoot rays down from a point just above the max Y position of the mesh.
     // Compute ray-triangle intersection tests against the ray and this mesh to 
@@ -225,14 +225,24 @@ void Mesh::generateHeightmap(const char* filename)
             // Write height value normalized between 0-255 (between min and max height)
             float h = heights[y*width + x];
             float nh = (h - minHeight) / maxHeight;
-            int bits = (int)(nh * 16777215.0f); // 2^24-1
-
             int pos = x*3;
-            row[pos+2] = (png_byte)(bits & 0xff);
-            bits >>= 8;
-            row[pos+1] = (png_byte)(bits & 0xff);
-            bits >>= 8;
-            row[pos] = (png_byte)(bits & 0xff);
+            if (highP)
+            {
+                // high precision packed 24-bit (RGB)
+                int bits = (int)(nh * 16777215.0f); // 2^24-1
+
+                row[pos+2] = (png_byte)(bits & 0xff);
+                bits >>= 8;
+                row[pos+1] = (png_byte)(bits & 0xff);
+                bits >>= 8;
+                row[pos] = (png_byte)(bits & 0xff);
+            }
+            else
+            {
+                // standard precision 8-bit (grayscale)
+                png_byte b = (png_byte)(nh * 255.0f);
+                row[pos] = row[pos+1] = row[pos+2] = b;
+            }
         }
         png_write_row(png_ptr, row);
     }

--- a/gameplay-encoder/src/Mesh.h
+++ b/gameplay-encoder/src/Mesh.h
@@ -62,8 +62,10 @@ public:
 
     /**
      * Generates a heightmap with the given filename for this mesh.
+     * Optional high precision uses packed 24-bit (RGB) instead of
+     * standard 8-bit grayscale.
      */
-    void generateHeightmap(const char* filename);
+    void generateHeightmap(const char* filename, bool highP = false);
 
     void computeBounds();
 

--- a/gameplay-encoder/src/Node.cpp
+++ b/gameplay-encoder/src/Node.cpp
@@ -137,7 +137,7 @@ void Node::generateHeightmap()
             heightmapFilename += getId();
             heightmapFilename += ".png";
 
-            mesh->generateHeightmap(heightmapFilename.c_str());
+            mesh->generateHeightmap(heightmapFilename.c_str(), EncoderArguments::getInstance()->isHeightmapHighP());
         }
     }
 }


### PR DESCRIPTION
High precision is available via '-hp' instead of '-h'. Tested grayscale output for -h and packed RGB output for -hp. This commit is source code only; the gameplay-encoder binaries will need to be regenerated.
