### PR TITLE
Scene::createScene() renamed to Scene::create() 

### DIFF
--- a/gameplay-samples/sample04-particles/src/ParticlesGame.cpp
+++ b/gameplay-samples/sample04-particles/src/ParticlesGame.cpp
@@ -36,7 +36,7 @@ void ParticlesGame::initialize()
     // The camera node is a child of a node at the same location as the particle emitter.
     // The camera node is offset from its parent, looking straight at it.
     // That way, when we rotate the parent node, the camera stays aimed at the particle emitter.
-    _scene = Scene::createScene();
+    _scene = Scene::create();
     Node* cameraNode = _scene->addNode("Camera");
     _cameraParent = _scene->addNode("CameraParent");
     _cameraParent->addChild(cameraNode);

--- a/gameplay/src/Bundle.cpp
+++ b/gameplay/src/Bundle.cpp
@@ -394,7 +394,7 @@ Scene* Bundle::loadScene(const char* id)
         }
     }
     
-    Scene* scene = Scene::createScene();
+    Scene* scene = Scene::create();
     scene->setId(getIdFromOffset());
 
     // Read the number of children.

--- a/gameplay/src/PlatformWin32.cpp
+++ b/gameplay/src/PlatformWin32.cpp
@@ -33,6 +33,7 @@ static HGLRC __hrc = 0;
 static bool __mouseCaptured = false;
 static POINT __mouseCapturePoint = { 0, 0 };
 static bool __cursorVisible = true;
+static unsigned int __gamepadsConnected = 0;
 
 #ifdef USE_XINPUT
 struct XInputGamepad
@@ -46,7 +47,6 @@ struct XInputGamepad
     XINPUT_STATE state;
 };
 
-static unsigned int __xinputGamepadsConnected = 0;
 static XInputGamepad* __xinputGamepads = NULL;
 
 static DWORD getXInputGamepadButtonMask(unsigned int buttonHandle)
@@ -1022,16 +1022,16 @@ void Platform::displayKeyboard(bool display)
 unsigned int Platform::getGamepadsConnected()
 {
     // Check to see what xbox360 gamepads are connected.
-    __xinputGamepadsConnected = 0;
+    __gamepadsConnected = 0;
 
 #ifdef USE_XINPUT
     for (unsigned int i = 0; i < XUSER_MAX_COUNT; i++)
     {
         if (isGamepadConnected(i))
-            __xinputGamepadsConnected++;
+            __gamepadsConnected++;
     }    
 #endif
-    return __xinputGamepadsConnected;
+    return __gamepadsConnected;
 }
 
 bool Platform::isGamepadConnected(unsigned int gamepadHandle)

--- a/gameplay/src/Scene.cpp
+++ b/gameplay/src/Scene.cpp
@@ -31,7 +31,7 @@ Scene::~Scene()
     SAFE_DELETE(_debugBatch);
 }
 
-Scene* Scene::createScene()
+Scene* Scene::create()
 {
     return new Scene();
 }

--- a/gameplay/src/Scene.h
+++ b/gameplay/src/Scene.h
@@ -30,7 +30,7 @@ public:
      * @return The newly created empty scene.
      * @script{create}
      */
-    static Scene* createScene();
+    static Scene* create();
 
     /**
      * Loads a scene from the given '.scene' file.

--- a/gameplay/src/lua/lua_Scene.cpp
+++ b/gameplay/src/lua/lua_Scene.cpp
@@ -39,7 +39,7 @@ void luaRegister_Scene()
     };
     const luaL_Reg lua_statics[] = 
     {
-        {"createScene", lua_Scene_static_createScene},
+        {"create", lua_Scene_static_create},
         {"load", lua_Scene_static_load},
         {NULL, NULL}
     };
@@ -897,7 +897,7 @@ int lua_Scene_setId(lua_State* state)
     return 0;
 }
 
-int lua_Scene_static_createScene(lua_State* state)
+int lua_Scene_static_create(lua_State* state)
 {
     // Get the number of parameters.
     int paramCount = lua_gettop(state);
@@ -907,7 +907,7 @@ int lua_Scene_static_createScene(lua_State* state)
     {
         case 0:
         {
-            void* returnPtr = (void*)Scene::createScene();
+            void* returnPtr = (void*)Scene::create();
             if (returnPtr)
             {
                 ScriptUtil::LuaObject* object = (ScriptUtil::LuaObject*)lua_newuserdata(state, sizeof(ScriptUtil::LuaObject));

--- a/gameplay/src/lua/lua_Scene.h
+++ b/gameplay/src/lua/lua_Scene.h
@@ -23,7 +23,7 @@ int lua_Scene_removeNode(lua_State* state);
 int lua_Scene_setActiveCamera(lua_State* state);
 int lua_Scene_setAmbientColor(lua_State* state);
 int lua_Scene_setId(lua_State* state);
-int lua_Scene_static_createScene(lua_State* state);
+int lua_Scene_static_create(lua_State* state);
 int lua_Scene_static_load(lua_State* state);
 int lua_Scene_visit(lua_State* state);
 


### PR DESCRIPTION
Changes Scene::createScene to Scene::create (break compat.)
Updated ParticlesGame.cpp which was the only sample that was using it.
Fixed error in PlatformWin32.cpp for previous gamepad commit.
