### PR TITLE
Texture distortion fix

### DIFF
--- a/gameplay/src/Texture.cpp
+++ b/gameplay/src/Texture.cpp
@@ -159,6 +159,7 @@ Texture* Texture::create(Format format, unsigned int width, unsigned int height,
     GLuint textureId;
     GL_ASSERT( glGenTextures(1, &textureId) );
     GL_ASSERT( glBindTexture(GL_TEXTURE_2D, textureId) );
+    GL_ASSERT( glPixelStorei(GL_UNPACK_ALIGNMENT, 1) );
     GL_ASSERT( glTexImage2D(GL_TEXTURE_2D, 0, (GLenum)format, width, height, 0, (GLenum)format, GL_UNSIGNED_BYTE, data) );
 
 
@@ -722,13 +723,13 @@ Texture* Texture::createCompressedDDS(const char* path)
         }
         else
         {
+            // TODO: For uncompressed formats, set GL_UNPACK_ALIGNMENT based on stride
             GL_ASSERT( glTexImage2D(GL_TEXTURE_2D, i, internalFormat, mipLevels[i].width, mipLevels[i].height, 0, format, GL_UNSIGNED_INT, mipLevels[i].data) );
         }
-        
+
         // Clean up the texture data.
         SAFE_DELETE_ARRAY(mipLevels[i].data);
     }
-    
 
     // Clean up mip levels structure.
     SAFE_DELETE_ARRAY(mipLevels);

--- a/gameplay/src/Texture.h
+++ b/gameplay/src/Texture.h
@@ -152,12 +152,27 @@ public:
 
     /**
      * Creates a texture from the given image.
+     *
+     * @param image The image containing the texture data.
+     * @param generateMipmaps True to generate a full mipmap chain, false otherwise.
+     *
+     * @return The new texture, or NULL if the image is not of a supported texture format.
      * @script{create}
      */
     static Texture* create(Image* image, bool generateMipmaps = false);
 
     /**
      * Creates a texture from the given texture data.
+     *
+     * The data in the texture is expected to be tightly packed (no padding at the end of rows).
+     *
+     * @param format Format of the texture data.
+     * @param width Width of the texture data.
+     * @param height Height of the texture data.
+     * @param data Raw texture data (expected to be tightly packed).
+     * @param generateMipmaps True to generate a full mipmap chain, false otherwise.
+     *
+     * @return The new texture.
      * @script{create}
      */
     static Texture* create(Format format, unsigned int width, unsigned int height, unsigned char* data, bool generateMipmaps = false);


### PR DESCRIPTION
Fixed issue where non four byte aligned textures (such as many non power of two textures) were distorted due to incorrect GL_UNPACK_ALIGNMENT.

Fixes #362
