### PR TITLE
Fix for Game::getAbsoluteTime() on Windows

### DIFF
--- a/gameplay/src/PlatformWindows.cpp
+++ b/gameplay/src/PlatformWindows.cpp
@@ -1109,7 +1109,7 @@ double Platform::getAbsoluteTime()
     GP_ASSERT(__timeTicksPerMillis);
     __timeAbsolute = queryTime.QuadPart / __timeTicksPerMillis;
 
-    return __timeAbsolute;
+    return __timeAbsolute - __timeStart;
 }
 
 void Platform::setAbsoluteTime(double time)


### PR DESCRIPTION
Fixes #507
