### PR TITLE
Exposed linearFactor and angularFactor from Bullet to PhysicsRigidBody

### DIFF
--- a/gameplay/src/PhysicsRigidBody.cpp
+++ b/gameplay/src/PhysicsRigidBody.cpp
@@ -43,6 +43,8 @@ PhysicsRigidBody::PhysicsRigidBody(Node* node, const PhysicsCollisionShape::Defi
     // Set other initially defined properties.
     setKinematic(parameters.kinematic);
     setAnisotropicFriction(parameters.anisotropicFriction);
+    setAngularFactor(parameters.angularFactor);
+    setLinearFactor(parameters.linearFactor);
 
     // Add ourself to the physics world.
     Game::getInstance()->getPhysicsController()->addCollisionObject(this);
@@ -222,6 +224,14 @@ PhysicsRigidBody* PhysicsRigidBody::create(Node* node, Properties* properties, c
         {
             gravity = new Vector3();
             properties->getVector3(NULL, gravity);
+        }
+        else if (strcmp(name, "angularFactor") == 0)
+        {
+            properties->getVector3(NULL, &parameters.angularFactor);
+        }
+        else if (strcmp(name, "linearFactor") == 0)
+        {
+            properties->getVector3(NULL, &parameters.linearFactor);
         }
         else
         {

--- a/gameplay/src/PhysicsRigidBody.h
+++ b/gameplay/src/PhysicsRigidBody.h
@@ -74,11 +74,25 @@ public:
         Vector3 anisotropicFriction;
 
         /**
+         * Linear factor for the rigid body. x, y, z coordinates correspond to world 
+         * space motion along these axes. Use 1.0 to allow or 0.0 to disallow motion 
+         * along certain axis.
+         */
+        Vector3 linearFactor;
+
+        /**
+         * Angular factor for the rigid body. x, y, z coordinates correspond to world 
+         * space rotation along these axes. Use 1.0 to allow or 0.0 to disallow rotation
+         * along certain axis.
+         */
+        Vector3 angularFactor;
+
+        /**
          * Constructor.
          */
         Parameters() : mass(0.0f), friction(0.5f), restitution(0.0f),
             linearDamping(0.0f), angularDamping(0.0f),
-            kinematic(false), anisotropicFriction(Vector3::one())
+            kinematic(false), anisotropicFriction(Vector3::one()), linearFactor(Vector3::one()), angularFactor(Vector3::one())
         {
         }
 
@@ -87,9 +101,10 @@ public:
          */
         Parameters(float mass, float friction = 0.5f, float resititution = 0.0f,
             float linearDamping = 0.0f, float angularDamping = 0.0f, bool kinematic = false,
-            const Vector3& anisotropicFriction = Vector3::one())
+            const Vector3& anisotropicFriction = Vector3::one(), const Vector3& linearFactor = Vector3::one(), 
+            const Vector3& angularFactor = Vector3::one())
             : mass(mass), friction(friction), restitution(restitution), linearDamping(linearDamping), angularDamping(angularDamping),
-              kinematic(kinematic), anisotropicFriction(anisotropicFriction)
+              kinematic(kinematic), anisotropicFriction(anisotropicFriction), linearFactor(linearFactor), angularFactor(angularFactor)
         {
         }
     };
@@ -248,6 +263,60 @@ public:
      * @param z The z coordinate of the gravity vector.
      */
     inline void setGravity(float x, float y, float z);
+
+    /**
+     * Gets the rigid body's angular factor.
+     * 
+     * @return The angular factor.
+     */
+    inline Vector3 getAngularFactor() const;
+
+    /**
+     * Sets the rigid body's angular factor.  x, y, z coordinates correspond to world 
+     * space rotation along these axes. Use 1.0 to allow or 0.0 to disallow rotation 
+     * along certain axis.
+     * 
+     * @param angularFactor angular factor vector
+     */
+    inline void setAngularFactor(const Vector3& angularFactor);
+
+    /**
+     * Sets the rigid body's angular factor.  x, y, z coordinates correspond to world 
+     * space rotation along these axes. Use 1.0 to allow or 0.0 to disallow rotation 
+     * along certain axis.
+     * 
+     * @param x The x coordinate of the angular factor vector.
+     * @param y The y coordinate of the angular factor vector.
+     * @param z The z coordinate of the angular factor vector.
+     */
+    inline void setAngularFactor(float x, float y, float z);
+
+    /**
+     * Gets the rigid body's linear factor.
+     * 
+     * @return The linear factor.
+     */
+    inline Vector3 getLinearFactor() const;
+
+    /**
+     * Sets the rigid body's linear factor.  x, y, z coordinates correspond to world 
+     * space motion along these axes. Use 1.0 to allow or 0.0 to disallow motion 
+     * along certain axis.
+     * 
+     * @param linearFactor linear factor vector
+     */
+    inline void setLinearFactor(const Vector3& linearFactor);
+
+    /**
+     * Sets the rigid body's linear factor.  x, y, z coordinates correspond to world 
+     * space motion along these axes. Use 1.0 to allow or 0.0 to disallow motion 
+     * along certain axis.
+     * 
+     * @param x The x coordinate of the linear factor vector.
+     * @param y The y coordinate of the linear factor vector.
+     * @param z The z coordinate of the linear factor vector.
+     */
+    inline void setLinearFactor(float x, float y, float z);
 
     /**
      * Sets whether the rigid body is a kinematic rigid body or not.

--- a/gameplay/src/PhysicsRigidBody.inl
+++ b/gameplay/src/PhysicsRigidBody.inl
@@ -127,6 +127,44 @@ inline void PhysicsRigidBody::setGravity(float x, float y, float z)
     _body->setGravity(btVector3(x, y, z));
 }
 
+inline Vector3 PhysicsRigidBody::getAngularFactor() const
+{
+    GP_ASSERT(_body);
+    const btVector3& f = _body->getAngularFactor();
+    return Vector3(f.x(), f.y(), f.z());
+}
+
+inline void PhysicsRigidBody::setAngularFactor(const Vector3& angularFactor)
+{
+    GP_ASSERT(_body);
+    _body->setAngularFactor(BV(angularFactor));
+}
+
+inline void PhysicsRigidBody::setAngularFactor(float x, float y, float z)
+{
+    GP_ASSERT(_body);
+    _body->setAngularFactor(btVector3(x, y, z));
+}
+
+inline Vector3 PhysicsRigidBody::getLinearFactor() const
+{
+    GP_ASSERT(_body);
+    const btVector3& f = _body->getLinearFactor();
+    return Vector3(f.x(), f.y(), f.z());
+}
+
+inline void PhysicsRigidBody::setLinearFactor(const Vector3& angularFactor)
+{
+    GP_ASSERT(_body);
+    _body->setLinearFactor(BV(angularFactor));
+}
+
+inline void PhysicsRigidBody::setLinearFactor(float x, float y, float z)
+{
+    GP_ASSERT(_body);
+    _body->setLinearFactor(btVector3(x, y, z));
+}
+
 inline bool PhysicsRigidBody::isStatic() const
 {
     GP_ASSERT(_body);

--- a/gameplay/src/lua/lua_PhysicsRigidBody.cpp
+++ b/gameplay/src/lua/lua_PhysicsRigidBody.cpp
@@ -33,6 +33,7 @@ void luaRegister_PhysicsRigidBody()
         {"applyTorqueImpulse", lua_PhysicsRigidBody_applyTorqueImpulse},
         {"collidesWith", lua_PhysicsRigidBody_collidesWith},
         {"getAngularDamping", lua_PhysicsRigidBody_getAngularDamping},
+        {"getAngularFactor", lua_PhysicsRigidBody_getAngularFactor},
         {"getAngularVelocity", lua_PhysicsRigidBody_getAngularVelocity},
         {"getAnisotropicFriction", lua_PhysicsRigidBody_getAnisotropicFriction},
         {"getCollisionShape", lua_PhysicsRigidBody_getCollisionShape},
@@ -40,6 +41,7 @@ void luaRegister_PhysicsRigidBody()
         {"getGravity", lua_PhysicsRigidBody_getGravity},
         {"getHeight", lua_PhysicsRigidBody_getHeight},
         {"getLinearDamping", lua_PhysicsRigidBody_getLinearDamping},
+        {"getLinearFactor", lua_PhysicsRigidBody_getLinearFactor},
         {"getLinearVelocity", lua_PhysicsRigidBody_getLinearVelocity},
         {"getMass", lua_PhysicsRigidBody_getMass},
         {"getNode", lua_PhysicsRigidBody_getNode},
@@ -51,6 +53,7 @@ void luaRegister_PhysicsRigidBody()
         {"isKinematic", lua_PhysicsRigidBody_isKinematic},
         {"isStatic", lua_PhysicsRigidBody_isStatic},
         {"removeCollisionListener", lua_PhysicsRigidBody_removeCollisionListener},
+        {"setAngularFactor", lua_PhysicsRigidBody_setAngularFactor},
         {"setAngularVelocity", lua_PhysicsRigidBody_setAngularVelocity},
         {"setAnisotropicFriction", lua_PhysicsRigidBody_setAnisotropicFriction},
         {"setDamping", lua_PhysicsRigidBody_setDamping},
@@ -58,6 +61,7 @@ void luaRegister_PhysicsRigidBody()
         {"setFriction", lua_PhysicsRigidBody_setFriction},
         {"setGravity", lua_PhysicsRigidBody_setGravity},
         {"setKinematic", lua_PhysicsRigidBody_setKinematic},
+        {"setLinearFactor", lua_PhysicsRigidBody_setLinearFactor},
         {"setLinearVelocity", lua_PhysicsRigidBody_setLinearVelocity},
         {"setRestitution", lua_PhysicsRigidBody_setRestitution},
         {NULL, NULL}
@@ -441,6 +445,52 @@ int lua_PhysicsRigidBody_getAngularDamping(lua_State* state)
     return 0;
 }
 
+int lua_PhysicsRigidBody_getAngularFactor(lua_State* state)
+{
+    // Get the number of parameters.
+    int paramCount = lua_gettop(state);
+
+    // Attempt to match the parameters to a valid binding.
+    switch (paramCount)
+    {
+        case 1:
+        {
+            if ((lua_type(state, 1) == LUA_TUSERDATA))
+            {
+                PhysicsRigidBody* instance = getInstance(state);
+                void* returnPtr = (void*)new Vector3(instance->getAngularFactor());
+                if (returnPtr)
+                {
+                    ScriptUtil::LuaObject* object = (ScriptUtil::LuaObject*)lua_newuserdata(state, sizeof(ScriptUtil::LuaObject));
+                    object->instance = returnPtr;
+                    object->owns = true;
+                    luaL_getmetatable(state, "Vector3");
+                    lua_setmetatable(state, -2);
+                }
+                else
+                {
+                    lua_pushnil(state);
+                }
+
+                return 1;
+            }
+            else
+            {
+                lua_pushstring(state, "lua_PhysicsRigidBody_getAngularFactor - Failed to match the given parameters to a valid function signature.");
+                lua_error(state);
+            }
+            break;
+        }
+        default:
+        {
+            lua_pushstring(state, "Invalid number of parameters (expected 1).");
+            lua_error(state);
+            break;
+        }
+    }
+    return 0;
+}
+
 int lua_PhysicsRigidBody_getAngularVelocity(lua_State* state)
 {
     // Get the number of parameters.
@@ -774,6 +824,53 @@ int lua_PhysicsRigidBody_getLinearDamping(lua_State* state)
     }
     return 0;
 }
+
+int lua_PhysicsRigidBody_getLinearFactor(lua_State* state)
+{
+    // Get the number of parameters.
+    int paramCount = lua_gettop(state);
+
+    // Attempt to match the parameters to a valid binding.
+    switch (paramCount)
+    {
+        case 1:
+        {
+            if ((lua_type(state, 1) == LUA_TUSERDATA))
+            {
+                PhysicsRigidBody* instance = getInstance(state);
+                void* returnPtr = (void*)new Vector3(instance->getLinearFactor());
+                if (returnPtr)
+                {
+                    ScriptUtil::LuaObject* object = (ScriptUtil::LuaObject*)lua_newuserdata(state, sizeof(ScriptUtil::LuaObject));
+                    object->instance = returnPtr;
+                    object->owns = true;
+                    luaL_getmetatable(state, "Vector3");
+                    lua_setmetatable(state, -2);
+                }
+                else
+                {
+                    lua_pushnil(state);
+                }
+
+                return 1;
+            }
+            else
+            {
+                lua_pushstring(state, "lua_PhysicsRigidBody_getLinearFactor - Failed to match the given parameters to a valid function signature.");
+                lua_error(state);
+            }
+            break;
+        }
+        default:
+        {
+            lua_pushstring(state, "Invalid number of parameters (expected 1).");
+            lua_error(state);
+            break;
+        }
+    }
+    return 0;
+}
+
 
 int lua_PhysicsRigidBody_getLinearVelocity(lua_State* state)
 {
@@ -1251,6 +1348,72 @@ int lua_PhysicsRigidBody_removeCollisionListener(lua_State* state)
     return 0;
 }
 
+int lua_PhysicsRigidBody_setAngularFactor(lua_State* state)
+{
+    // Get the number of parameters.
+    int paramCount = lua_gettop(state);
+
+    // Attempt to match the parameters to a valid binding.
+    switch (paramCount)
+    {
+        case 2:
+        {
+            if ((lua_type(state, 1) == LUA_TUSERDATA) &&
+                (lua_type(state, 2) == LUA_TUSERDATA || lua_type(state, 2) == LUA_TNIL))
+            {
+                // Get parameter 1 off the stack.
+                ScriptUtil::LuaArray<Vector3> param1 = ScriptUtil::getObjectPointer<Vector3>(2, "Vector3", true);
+
+                PhysicsRigidBody* instance = getInstance(state);
+                instance->setAngularFactor(*param1);
+                
+                return 0;
+            }
+            else
+            {
+                lua_pushstring(state, "lua_PhysicsRigidBody_setAngularFactor - Failed to match the given parameters to a valid function signature.");
+                lua_error(state);
+            }
+            break;
+        }
+        case 4:
+        {
+            if ((lua_type(state, 1) == LUA_TUSERDATA) &&
+                lua_type(state, 2) == LUA_TNUMBER &&
+                lua_type(state, 3) == LUA_TNUMBER &&
+                lua_type(state, 4) == LUA_TNUMBER)
+            {
+                // Get parameter 1 off the stack.
+                float param1 = (float)luaL_checknumber(state, 2);
+
+                // Get parameter 2 off the stack.
+                float param2 = (float)luaL_checknumber(state, 3);
+
+                // Get parameter 3 off the stack.
+                float param3 = (float)luaL_checknumber(state, 4);
+
+                PhysicsRigidBody* instance = getInstance(state);
+                instance->setAngularFactor(param1, param2, param3);
+                
+                return 0;
+            }
+            else
+            {
+                lua_pushstring(state, "lua_PhysicsRigidBody_setAngularFactor - Failed to match the given parameters to a valid function signature.");
+                lua_error(state);
+            }
+            break;
+        }
+        default:
+        {
+            lua_pushstring(state, "Invalid number of parameters (expected 2 or 4).");
+            lua_error(state);
+            break;
+        }
+    }
+    return 0;
+}
+
 int lua_PhysicsRigidBody_setAngularVelocity(lua_State* state)
 {
     // Get the number of parameters.
@@ -1598,6 +1761,72 @@ int lua_PhysicsRigidBody_setKinematic(lua_State* state)
         default:
         {
             lua_pushstring(state, "Invalid number of parameters (expected 2).");
+            lua_error(state);
+            break;
+        }
+    }
+    return 0;
+}
+
+int lua_PhysicsRigidBody_setLinearFactor(lua_State* state)
+{
+    // Get the number of parameters.
+    int paramCount = lua_gettop(state);
+
+    // Attempt to match the parameters to a valid binding.
+    switch (paramCount)
+    {
+        case 2:
+        {
+            if ((lua_type(state, 1) == LUA_TUSERDATA) &&
+                (lua_type(state, 2) == LUA_TUSERDATA || lua_type(state, 2) == LUA_TNIL))
+            {
+                // Get parameter 1 off the stack.
+                ScriptUtil::LuaArray<Vector3> param1 = ScriptUtil::getObjectPointer<Vector3>(2, "Vector3", true);
+
+                PhysicsRigidBody* instance = getInstance(state);
+                instance->setLinearFactor(*param1);
+                
+                return 0;
+            }
+            else
+            {
+                lua_pushstring(state, "lua_PhysicsRigidBody_setLinearFactor - Failed to match the given parameters to a valid function signature.");
+                lua_error(state);
+            }
+            break;
+        }
+        case 4:
+        {
+            if ((lua_type(state, 1) == LUA_TUSERDATA) &&
+                lua_type(state, 2) == LUA_TNUMBER &&
+                lua_type(state, 3) == LUA_TNUMBER &&
+                lua_type(state, 4) == LUA_TNUMBER)
+            {
+                // Get parameter 1 off the stack.
+                float param1 = (float)luaL_checknumber(state, 2);
+
+                // Get parameter 2 off the stack.
+                float param2 = (float)luaL_checknumber(state, 3);
+
+                // Get parameter 3 off the stack.
+                float param3 = (float)luaL_checknumber(state, 4);
+
+                PhysicsRigidBody* instance = getInstance(state);
+                instance->setLinearFactor(param1, param2, param3);
+                
+                return 0;
+            }
+            else
+            {
+                lua_pushstring(state, "lua_PhysicsRigidBody_setLinearFactor - Failed to match the given parameters to a valid function signature.");
+                lua_error(state);
+            }
+            break;
+        }
+        default:
+        {
+            lua_pushstring(state, "Invalid number of parameters (expected 2 or 4).");
             lua_error(state);
             break;
         }

--- a/gameplay/src/lua/lua_PhysicsRigidBody.h
+++ b/gameplay/src/lua/lua_PhysicsRigidBody.h
@@ -23,6 +23,8 @@ int lua_PhysicsRigidBody_getLinearVelocity(lua_State* state);
 int lua_PhysicsRigidBody_getMass(lua_State* state);
 int lua_PhysicsRigidBody_getNode(lua_State* state);
 int lua_PhysicsRigidBody_getRestitution(lua_State* state);
+int lua_PhysicsRigidBody_getLinearFactor(lua_State* state);
+int lua_PhysicsRigidBody_getAngularFactor(lua_State* state);
 int lua_PhysicsRigidBody_getShapeType(lua_State* state);
 int lua_PhysicsRigidBody_getType(lua_State* state);
 int lua_PhysicsRigidBody_isDynamic(lua_State* state);
@@ -39,6 +41,8 @@ int lua_PhysicsRigidBody_setGravity(lua_State* state);
 int lua_PhysicsRigidBody_setKinematic(lua_State* state);
 int lua_PhysicsRigidBody_setLinearVelocity(lua_State* state);
 int lua_PhysicsRigidBody_setRestitution(lua_State* state);
+int lua_PhysicsRigidBody_setLinearFactor(lua_State* state);
+int lua_PhysicsRigidBody_setAngularFactor(lua_State* state);
 
 void luaRegister_PhysicsRigidBody();
 

--- a/gameplay/src/lua/lua_PhysicsRigidBodyParameters.cpp
+++ b/gameplay/src/lua/lua_PhysicsRigidBodyParameters.cpp
@@ -27,10 +27,12 @@ void luaRegister_PhysicsRigidBodyParameters()
     const luaL_Reg lua_members[] = 
     {
         {"angularDamping", lua_PhysicsRigidBodyParameters_angularDamping},
+        {"angularFactor", lua_PhysicsRigidBodyParameters_angularFactor},
         {"anisotropicFriction", lua_PhysicsRigidBodyParameters_anisotropicFriction},
         {"friction", lua_PhysicsRigidBodyParameters_friction},
         {"kinematic", lua_PhysicsRigidBodyParameters_kinematic},
         {"linearDamping", lua_PhysicsRigidBodyParameters_linearDamping},
+        {"linearFactor", lua_PhysicsRigidBodyParameters_linearFactor},
         {"mass", lua_PhysicsRigidBodyParameters_mass},
         {"restitution", lua_PhysicsRigidBodyParameters_restitution},
         {NULL, NULL}
@@ -410,9 +412,129 @@ int lua_PhysicsRigidBodyParameters__init(lua_State* state)
             }
             break;
         }
+        case 8:
+        {
+            if (lua_type(state, 1) == LUA_TNUMBER &&
+                lua_type(state, 2) == LUA_TNUMBER &&
+                lua_type(state, 3) == LUA_TNUMBER &&
+                lua_type(state, 4) == LUA_TNUMBER &&
+                lua_type(state, 5) == LUA_TNUMBER &&
+                lua_type(state, 6) == LUA_TBOOLEAN &&
+                (lua_type(state, 7) == LUA_TUSERDATA || lua_type(state, 7) == LUA_TNIL) &&
+                (lua_type(state, 8) == LUA_TUSERDATA || lua_type(state, 8) == LUA_TNIL))
+            {
+                // Get parameter 1 off the stack.
+                float param1 = (float)luaL_checknumber(state, 1);
+
+                // Get parameter 2 off the stack.
+                float param2 = (float)luaL_checknumber(state, 2);
+
+                // Get parameter 3 off the stack.
+                float param3 = (float)luaL_checknumber(state, 3);
+
+                // Get parameter 4 off the stack.
+                float param4 = (float)luaL_checknumber(state, 4);
+
+                // Get parameter 5 off the stack.
+                float param5 = (float)luaL_checknumber(state, 5);
+
+                // Get parameter 6 off the stack.
+                bool param6 = ScriptUtil::luaCheckBool(state, 6);
+
+                // Get parameter 7 off the stack.
+                ScriptUtil::LuaArray<Vector3> param7 = ScriptUtil::getObjectPointer<Vector3>(7, "Vector3", true);
+
+                // Get parameter 8 off the stack.
+                ScriptUtil::LuaArray<Vector3> param8 = ScriptUtil::getObjectPointer<Vector3>(8, "Vector3", true);
+
+                void* returnPtr = (void*)new PhysicsRigidBody::Parameters(param1, param2, param3, param4, param5, param6, *param7, *param8);
+                if (returnPtr)
+                {
+                    ScriptUtil::LuaObject* object = (ScriptUtil::LuaObject*)lua_newuserdata(state, sizeof(ScriptUtil::LuaObject));
+                    object->instance = returnPtr;
+                    object->owns = true;
+                    luaL_getmetatable(state, "PhysicsRigidBodyParameters");
+                    lua_setmetatable(state, -2);
+                }
+                else
+                {
+                    lua_pushnil(state);
+                }
+
+                return 1;
+            }
+            else
+            {
+                lua_pushstring(state, "lua_PhysicsRigidBodyParameters__init - Failed to match the given parameters to a valid function signature.");
+                lua_error(state);
+            }
+            break;
+        }
+        case 9:
+        {
+            if (lua_type(state, 1) == LUA_TNUMBER &&
+                lua_type(state, 2) == LUA_TNUMBER &&
+                lua_type(state, 3) == LUA_TNUMBER &&
+                lua_type(state, 4) == LUA_TNUMBER &&
+                lua_type(state, 5) == LUA_TNUMBER &&
+                lua_type(state, 6) == LUA_TBOOLEAN &&
+                (lua_type(state, 7) == LUA_TUSERDATA || lua_type(state, 7) == LUA_TNIL) &&
+                (lua_type(state, 8) == LUA_TUSERDATA || lua_type(state, 8) == LUA_TNIL) &&
+                (lua_type(state, 9) == LUA_TUSERDATA || lua_type(state, 9) == LUA_TNIL))
+            {
+                // Get parameter 1 off the stack.
+                float param1 = (float)luaL_checknumber(state, 1);
+
+                // Get parameter 2 off the stack.
+                float param2 = (float)luaL_checknumber(state, 2);
+
+                // Get parameter 3 off the stack.
+                float param3 = (float)luaL_checknumber(state, 3);
+
+                // Get parameter 4 off the stack.
+                float param4 = (float)luaL_checknumber(state, 4);
+
+                // Get parameter 5 off the stack.
+                float param5 = (float)luaL_checknumber(state, 5);
+
+                // Get parameter 6 off the stack.
+                bool param6 = ScriptUtil::luaCheckBool(state, 6);
+
+                // Get parameter 7 off the stack.
+                ScriptUtil::LuaArray<Vector3> param7 = ScriptUtil::getObjectPointer<Vector3>(7, "Vector3", true);
+
+                // Get parameter 8 off the stack.
+                ScriptUtil::LuaArray<Vector3> param8 = ScriptUtil::getObjectPointer<Vector3>(8, "Vector3", true);
+                
+                // Get parameter 9 off the stack.
+                ScriptUtil::LuaArray<Vector3> param9 = ScriptUtil::getObjectPointer<Vector3>(9, "Vector3", true);
+
+                void* returnPtr = (void*)new PhysicsRigidBody::Parameters(param1, param2, param3, param4, param5, param6, *param7, *param8, *param9);
+                if (returnPtr)
+                {
+                    ScriptUtil::LuaObject* object = (ScriptUtil::LuaObject*)lua_newuserdata(state, sizeof(ScriptUtil::LuaObject));
+                    object->instance = returnPtr;
+                    object->owns = true;
+                    luaL_getmetatable(state, "PhysicsRigidBodyParameters");
+                    lua_setmetatable(state, -2);
+                }
+                else
+                {
+                    lua_pushnil(state);
+                }
+
+                return 1;
+            }
+            else
+            {
+                lua_pushstring(state, "lua_PhysicsRigidBodyParameters__init - Failed to match the given parameters to a valid function signature.");
+                lua_error(state);
+            }
+            break;
+        }
         default:
         {
-            lua_pushstring(state, "Invalid number of parameters (expected 0, 1, 2, 3, 4, 5, 6 or 7).");
+            lua_pushstring(state, "Invalid number of parameters (expected 0, 1, 2, 3, 4, 5, 6, 7, 8 or 9).");
             lua_error(state);
             break;
         }
@@ -444,6 +566,44 @@ int lua_PhysicsRigidBodyParameters_angularDamping(lua_State* state)
 
         // Push the return value onto the stack.
         lua_pushnumber(state, result);
+
+        return 1;
+    }
+}
+
+int lua_PhysicsRigidBodyParameters_angularFactor(lua_State* state)
+{
+    // Validate the number of parameters.
+    if (lua_gettop(state) > 2)
+    {
+        lua_pushstring(state, "Invalid number of parameters (expected 1 or 2).");
+        lua_error(state);
+    }
+
+    PhysicsRigidBody::Parameters* instance = getInstance(state);
+    if (lua_gettop(state) == 2)
+    {
+        // Get parameter 2 off the stack.
+        ScriptUtil::LuaArray<Vector3> param2 = ScriptUtil::getObjectPointer<Vector3>(2, "Vector3", true);
+
+        instance->angularFactor = *param2;
+        return 0;
+    }
+    else
+    {
+        void* returnPtr = (void*)new Vector3(instance->angularFactor);
+        if (returnPtr)
+        {
+            ScriptUtil::LuaObject* object = (ScriptUtil::LuaObject*)lua_newuserdata(state, sizeof(ScriptUtil::LuaObject));
+            object->instance = returnPtr;
+            object->owns = true;
+            luaL_getmetatable(state, "Vector3");
+            lua_setmetatable(state, -2);
+        }
+        else
+        {
+            lua_pushnil(state);
+        }
 
         return 1;
     }
@@ -569,6 +729,44 @@ int lua_PhysicsRigidBodyParameters_linearDamping(lua_State* state)
 
         // Push the return value onto the stack.
         lua_pushnumber(state, result);
+
+        return 1;
+    }
+}
+
+int lua_PhysicsRigidBodyParameters_linearFactor(lua_State* state)
+{
+    // Validate the number of parameters.
+    if (lua_gettop(state) > 2)
+    {
+        lua_pushstring(state, "Invalid number of parameters (expected 1 or 2).");
+        lua_error(state);
+    }
+
+    PhysicsRigidBody::Parameters* instance = getInstance(state);
+    if (lua_gettop(state) == 2)
+    {
+        // Get parameter 2 off the stack.
+        ScriptUtil::LuaArray<Vector3> param2 = ScriptUtil::getObjectPointer<Vector3>(2, "Vector3", true);
+
+        instance->linearFactor = *param2;
+        return 0;
+    }
+    else
+    {
+        void* returnPtr = (void*)new Vector3(instance->linearFactor);
+        if (returnPtr)
+        {
+            ScriptUtil::LuaObject* object = (ScriptUtil::LuaObject*)lua_newuserdata(state, sizeof(ScriptUtil::LuaObject));
+            object->instance = returnPtr;
+            object->owns = true;
+            luaL_getmetatable(state, "Vector3");
+            lua_setmetatable(state, -2);
+        }
+        else
+        {
+            lua_pushnil(state);
+        }
 
         return 1;
     }

--- a/gameplay/src/lua/lua_PhysicsRigidBodyParameters.h
+++ b/gameplay/src/lua/lua_PhysicsRigidBodyParameters.h
@@ -8,10 +8,12 @@ namespace gameplay
 int lua_PhysicsRigidBodyParameters__gc(lua_State* state);
 int lua_PhysicsRigidBodyParameters__init(lua_State* state);
 int lua_PhysicsRigidBodyParameters_angularDamping(lua_State* state);
+int lua_PhysicsRigidBodyParameters_angularFactor(lua_State* state);
 int lua_PhysicsRigidBodyParameters_anisotropicFriction(lua_State* state);
 int lua_PhysicsRigidBodyParameters_friction(lua_State* state);
 int lua_PhysicsRigidBodyParameters_kinematic(lua_State* state);
 int lua_PhysicsRigidBodyParameters_linearDamping(lua_State* state);
+int lua_PhysicsRigidBodyParameters_linearFactor(lua_State* state);
 int lua_PhysicsRigidBodyParameters_mass(lua_State* state);
 int lua_PhysicsRigidBodyParameters_restitution(lua_State* state);
 


### PR DESCRIPTION
Hi,

I requested this feature on the forums http://www.gameplay3d.org/forums/viewtopic.php?f=4&t=110 but then I thought - hey, it's open source, right? I can do it myself. So I did, I added setLinearFactor and setAngularFactor (Vector3 and float, float, float methods) and getLinearFactor / getAngularFactor methods. I also added these two to the parameters and modified lua bindings for both PhysicsRigidBody and PhysicsRigidBodyParameters. I haven't tested lua bindings though so please have a look at it, especially the part initialized for parameters (case with 8 and 9 parameters).

I hope I did everything right, I haven't ever used git.

Thanks and cheers,
Marcin Jakubowski
pooerh
