### PR TITLE
Fixes in shaders and material bindings

### DIFF
--- a/gameplay-samples/sample00-mesh/res/duck.material
+++ b/gameplay-samples/sample00-mesh/res/duck.material
@@ -11,7 +11,7 @@ material duck
             
             // uniforms
             u_worldViewProjectionMatrix = WORLD_VIEW_PROJECTION_MATRIX
-            u_inverseTransposeWorldViewMatrix = INVERSE_TRANSPOSE_WORLD_VIEW_MATRIX
+            u_inverseTransposeWorldMatrix = INVERSE_TRANSPOSE_WORLD_MATRIX
             u_cameraPosition = CAMERA_WORLD_POSITION
             u_ambientColor = 0.2, 0.2, 0.2
             u_lightColor = 0.75, 0.75, 0.75

--- a/gameplay-samples/sample02-spaceship/src/SpaceshipGame.cpp
+++ b/gameplay-samples/sample02-spaceship/src/SpaceshipGame.cpp
@@ -201,7 +201,7 @@ void SpaceshipGame::initializeMaterial(Material* material, bool lighting, bool s
     if (lighting)
     {
         // Apply lighting material parameters
-        material->setParameterAutoBinding("u_inverseTransposeWorldViewMatrix", RenderState::INVERSE_TRANSPOSE_WORLD_VIEW_MATRIX);
+        material->setParameterAutoBinding("u_inverseTransposeWorldMatrix", RenderState::INVERSE_TRANSPOSE_WORLD_MATRIX);
 
         Node* lightNode = _scene->findNode("directionalLight1");
         Vector3 lightDirection = lightNode->getForwardVector();

--- a/gameplay-samples/sample03-character/res/common/scene.material
+++ b/gameplay-samples/sample03-character/res/common/scene.material
@@ -38,7 +38,7 @@ material texturedSpecular
 			defines = SPECULAR
 
             u_worldViewProjectionMatrix = WORLD_VIEW_PROJECTION_MATRIX
-            u_inverseTransposeWorldViewMatrix = INVERSE_TRANSPOSE_WORLD_VIEW_MATRIX
+            u_inverseTransposeWorldMatrix = INVERSE_TRANSPOSE_WORLD_MATRIX
             u_worldViewMatrix = WORLD_VIEW_MATRIX
             u_cameraPosition = CAMERA_VIEW_POSITION
             u_specularExponent = 50
@@ -71,7 +71,7 @@ material texturedTransparent
             fragmentShader = res/shaders/textured.frag
 
             u_worldViewProjectionMatrix = WORLD_VIEW_PROJECTION_MATRIX
-            u_inverseTransposeWorldViewMatrix = INVERSE_TRANSPOSE_WORLD_VIEW_MATRIX
+            u_inverseTransposeWorldMatrix = INVERSE_TRANSPOSE_WORLD_MATRIX
             
             sampler u_diffuseTexture
             {
@@ -104,7 +104,7 @@ material colored
             fragmentShader = res/shaders/colored.frag
 
             u_worldViewProjectionMatrix = WORLD_VIEW_PROJECTION_MATRIX
-            u_inverseTransposeWorldViewMatrix = INVERSE_TRANSPOSE_WORLD_VIEW_MATRIX
+            u_inverseTransposeWorldMatrix = INVERSE_TRANSPOSE_WORLD_MATRIX
             
             renderState
             {

--- a/gameplay-samples/sample05-lua/res/box.material
+++ b/gameplay-samples/sample05-lua/res/box.material
@@ -11,7 +11,7 @@ material box
             
             // uniforms
             u_worldViewProjectionMatrix = WORLD_VIEW_PROJECTION_MATRIX
-            u_inverseTransposeWorldViewMatrix = INVERSE_TRANSPOSE_WORLD_VIEW_MATRIX
+            u_inverseTransposeWorldMatrix = INVERSE_TRANSPOSE_WORLD_MATRIX
             u_cameraPosition = CAMERA_WORLD_POSITION
             u_ambientColor = 0.2, 0.2, 0.2
             u_lightColor = 0.75, 0.75, 0.75

--- a/gameplay-samples/sample06-racer/res/common/game.material
+++ b/gameplay-samples/sample06-racer/res/common/game.material
@@ -2,7 +2,7 @@ material textured
 {
     // uniforms
     u_worldViewProjectionMatrix = WORLD_VIEW_PROJECTION_MATRIX
-    u_inverseTransposeWorldViewMatrix = INVERSE_TRANSPOSE_WORLD_VIEW_MATRIX
+    u_inverseTransposeWorldMatrix = INVERSE_TRANSPOSE_WORLD_MATRIX
 
     // samplers
     sampler u_diffuseTexture
@@ -80,7 +80,7 @@ material colored
 {
     // uniforms
     u_worldViewProjectionMatrix = WORLD_VIEW_PROJECTION_MATRIX
-    u_inverseTransposeWorldViewMatrix = INVERSE_TRANSPOSE_WORLD_VIEW_MATRIX
+    u_inverseTransposeWorldMatrix = INVERSE_TRANSPOSE_WORLD_MATRIX
 
     // render state
     renderState

--- a/gameplay-template/res/box.material
+++ b/gameplay-template/res/box.material
@@ -10,7 +10,7 @@ material box
             
             // uniforms
             u_worldViewProjectionMatrix = WORLD_VIEW_PROJECTION_MATRIX
-            u_inverseTransposeWorldViewMatrix = INVERSE_TRANSPOSE_WORLD_VIEW_MATRIX
+            u_inverseTransposeWorldMatrix = INVERSE_TRANSPOSE_WORLD_MATRIX
             u_diffuseColor = 1.0, 1.0, 1.0, 1.0
 
             // render state

--- a/gameplay-template/res/colored.vert
+++ b/gameplay-template/res/colored.vert
@@ -4,7 +4,7 @@ attribute vec3 a_normal;                            // Vertex Normal (x, y, z)
 
 // Uniforms
 uniform mat4 u_worldViewProjectionMatrix;           // Matrix to transform a position to clip space.
-uniform mat4 u_inverseTransposeWorldViewMatrix;     // Matrix to transform a normal to view space.
+uniform mat4 u_inverseTransposeWorldMatrix;         // Matrix to transform a normal to view space.
 
 // Outputs
 varying vec3 v_normalVector;                        // Normal vector in view space.
@@ -19,6 +19,6 @@ void main()
     gl_Position = u_worldViewProjectionMatrix * position;
 
     // Transform normal to view space.
-    mat3 inverseTransposeWorldViewMatrix = mat3(u_inverseTransposeWorldViewMatrix[0].xyz, u_inverseTransposeWorldViewMatrix[1].xyz, u_inverseTransposeWorldViewMatrix[2].xyz);
+    mat3 inverseTransposeWorldViewMatrix = mat3(u_inverseTransposeWorldMatrix[0].xyz, u_inverseTransposeWorldMatrix[1].xyz, u_inverseTransposeWorldMatrix[2].xyz);
     v_normalVector = inverseTransposeWorldViewMatrix * normal;
 }

--- a/gameplay-tests/res/common/box.material
+++ b/gameplay-tests/res/common/box.material
@@ -11,7 +11,7 @@ material box
             
             // uniforms
             u_worldViewProjectionMatrix = WORLD_VIEW_PROJECTION_MATRIX
-            u_inverseTransposeWorldViewMatrix = INVERSE_TRANSPOSE_WORLD_VIEW_MATRIX
+            u_inverseTransposeWorldMatrix = INVERSE_TRANSPOSE_WORLD_MATRIX
             u_cameraPosition = CAMERA_WORLD_POSITION
             u_ambientColor = 0.2, 0.2, 0.2
             u_lightColor = 0.75, 0.75, 0.75

--- a/gameplay-tests/res/common/duck.material
+++ b/gameplay-tests/res/common/duck.material
@@ -11,7 +11,7 @@ material duck
             
             // uniforms
             u_worldViewProjectionMatrix = WORLD_VIEW_PROJECTION_MATRIX
-            u_inverseTransposeWorldViewMatrix = INVERSE_TRANSPOSE_WORLD_VIEW_MATRIX
+            u_inverseTransposeWorldMatrix = INVERSE_TRANSPOSE_WORLD_MATRIX
             u_cameraPosition = CAMERA_WORLD_POSITION
             u_ambientColor = 0.2, 0.2, 0.2
             u_lightColor = 0.75, 0.75, 0.75

--- a/gameplay-tests/res/common/physics.material
+++ b/gameplay-tests/res/common/physics.material
@@ -8,7 +8,7 @@ material colored
             fragmentShader = res/shaders/colored.frag
 
             u_worldViewProjectionMatrix = WORLD_VIEW_PROJECTION_MATRIX
-            u_inverseTransposeWorldViewMatrix = INVERSE_TRANSPOSE_WORLD_VIEW_MATRIX
+            u_inverseTransposeWorldMatrix = INVERSE_TRANSPOSE_WORLD_MATRIX
             
             renderState
             {

--- a/gameplay-tests/res/common/scene.material
+++ b/gameplay-tests/res/common/scene.material
@@ -8,7 +8,7 @@ material colored
             fragmentShader = res/shaders/colored.frag
 
             u_worldViewProjectionMatrix = WORLD_VIEW_PROJECTION_MATRIX
-            u_inverseTransposeWorldViewMatrix = INVERSE_TRANSPOSE_WORLD_VIEW_MATRIX
+            u_inverseTransposeWorldMatrix = INVERSE_TRANSPOSE_WORLD_MATRIX
             
             renderState
             {

--- a/gameplay-tests/src/Audio3DTest.cpp
+++ b/gameplay-tests/src/Audio3DTest.cpp
@@ -83,8 +83,6 @@ void Audio3DTest::update(float elapsedTime)
 {
     float time = (float)elapsedTime / 1000.0f;
 
-    _gamepad->update(elapsedTime);
-
     Vector2 move;
 
     if (_moveFlags != 0)
@@ -137,6 +135,8 @@ void Audio3DTest::update(float elapsedTime)
         addSound("footsteps.wav");
     }
     _buttonPressed = _gamepad->getButtonState(BUTTON_A) == Gamepad::BUTTON_PRESSED;
+
+    _gamepad->update(elapsedTime);
 }
 
 void Audio3DTest::render(float elapsedTime)

--- a/gameplay-tests/src/CreateSceneTest.cpp
+++ b/gameplay-tests/src/CreateSceneTest.cpp
@@ -107,7 +107,7 @@ void CreateSceneTest::initialize()
     // These parameters are normally set in a .material file but this example sets them programmatically.
     // Bind the uniform "u_worldViewProjectionMatrix" to use the WORLD_VIEW_PROJECTION_MATRIX from the scene's active camera and the node that the model belongs to.
     material->setParameterAutoBinding("u_worldViewProjectionMatrix", "WORLD_VIEW_PROJECTION_MATRIX");
-    material->setParameterAutoBinding("u_inverseTransposeWorldViewMatrix", "INVERSE_TRANSPOSE_WORLD_VIEW_MATRIX");
+    material->setParameterAutoBinding("u_inverseTransposeWorldMatrix", "INVERSE_TRANSPOSE_WORLD_MATRIX");
 
     // Bind the light's direction to the material.
     material->getParameter("u_lightDirection")->bindValue(lightNode, &Node::getForwardVectorView);

--- a/gameplay-tests/src/MeshBatchTest.cpp
+++ b/gameplay-tests/src/MeshBatchTest.cpp
@@ -97,7 +97,7 @@ void MeshBatchTest::touchEvent(Touch::TouchEvent evt, int x, int y, unsigned int
     case Touch::TOUCH_RELEASE:
         break;
     case Touch::TOUCH_MOVE:
-        if (Game::getInstance()->getAbsoluteTime() - _lastTriangleAdded > 100)
+        if (Game::getInstance()->getAbsoluteTime() - _lastTriangleAdded > 50)
         {
             addTriangle( x - (getWidth() >>1), (getHeight() >> 1) - y);
         }

--- a/gameplay/res/shaders/colored.vert
+++ b/gameplay/res/shaders/colored.vert
@@ -14,7 +14,7 @@ varying vec3 v_color;										// Output Vertex Color
 
 // Uniforms
 uniform mat4 u_worldViewProjectionMatrix;					// Matrix to transform a position to clip space.
-uniform mat4 u_inverseTransposeWorldViewMatrix;				// Matrix to transform a normal to view space.
+uniform mat4 u_inverseTransposeWorldMatrix;				    // Matrix to transform a normal to view space.
 #if defined(SKINNING)
 uniform vec4 u_matrixPalette[SKINNING_JOINT_COUNT * 3];		// Array of 4x3 matrices
 #endif
@@ -68,7 +68,7 @@ void main()
     gl_Position = u_worldViewProjectionMatrix * position;
 
     // Transform normal to view space.
-    mat3 inverseTransposeWorldViewMatrix = mat3(u_inverseTransposeWorldViewMatrix[0].xyz, u_inverseTransposeWorldViewMatrix[1].xyz, u_inverseTransposeWorldViewMatrix[2].xyz);
+    mat3 inverseTransposeWorldViewMatrix = mat3(u_inverseTransposeWorldMatrix[0].xyz, u_inverseTransposeWorldMatrix[1].xyz, u_inverseTransposeWorldMatrix[2].xyz);
     v_normalVector = inverseTransposeWorldViewMatrix * normal;
 
     // Apply light.

--- a/gameplay/res/shaders/lib/attributes-skinning.vert
+++ b/gameplay/res/shaders/lib/attributes-skinning.vert
@@ -37,6 +37,8 @@ vec4 getPosition()
     return _skinnedPosition;    
 }
 
+#if defined(LIGHTING)
+
 void skinTangentSpaceVector(vec3 vector, float blendWeight, int matrixIndex)
 {
     vec3 tmp;
@@ -69,8 +71,6 @@ vec3 getTangentSpaceVector(vec3 vector)
 
     return _skinnedNormal;
 }
-
-#if defined(LIGHTING)
 
 vec3 getNormal()
 {

--- a/gameplay/res/shaders/textured-bumped.vert
+++ b/gameplay/res/shaders/textured-bumped.vert
@@ -14,7 +14,7 @@ attribute vec4 a_blendIndices;								// Vertex blend index int u_matrixPalette	
 
 // Uniforms
 uniform mat4 u_worldViewProjectionMatrix;					// Matrix to transform a position to clip space
-uniform mat4 u_inverseTransposeWorldViewMatrix;				// Matrix to transform a normal to view space
+uniform mat4 u_inverseTransposeWorldMatrix;				    // Matrix to transform a normal to view space
 #if defined(SKINNING)
 uniform vec4 u_matrixPalette[SKINNING_JOINT_COUNT * 3];		// Array of 4x3 matrices
 #endif
@@ -80,7 +80,7 @@ void main()
     gl_Position = u_worldViewProjectionMatrix * position;
 
     // Transform the normal, tangent and binormals to view space.
-    mat3 inverseTransposeWorldViewMatrix = mat3(u_inverseTransposeWorldViewMatrix[0].xyz, u_inverseTransposeWorldViewMatrix[1].xyz, u_inverseTransposeWorldViewMatrix[2].xyz);
+    mat3 inverseTransposeWorldViewMatrix = mat3(u_inverseTransposeWorldMatrix[0].xyz, u_inverseTransposeWorldMatrix[1].xyz, u_inverseTransposeWorldMatrix[2].xyz);
     vec3 normalVector = normalize(inverseTransposeWorldViewMatrix * normal);
     
     // Create a transform to convert a vector to tangent space.

--- a/gameplay/res/shaders/textured.vert
+++ b/gameplay/res/shaders/textured.vert
@@ -11,7 +11,7 @@ attribute vec4 a_blendIndices;								// Vertex blend index int u_matrixPalette	
 
 // Uniforms
 uniform mat4 u_worldViewProjectionMatrix;					// Matrix to transform a position to clip space
-uniform mat4 u_inverseTransposeWorldViewMatrix;				// Matrix to transform a normal to view space
+uniform mat4 u_inverseTransposeWorldMatrix;				    // Matrix to transform a normal to view space
 #if defined(SKINNING)
 uniform vec4 u_matrixPalette[SKINNING_JOINT_COUNT * 3];		// Array of 4x3 matrices
 #endif
@@ -70,7 +70,7 @@ void main()
     gl_Position = u_worldViewProjectionMatrix * position;
 
     // Transform normal to view space.
-    mat3 normalMatrix = mat3(u_inverseTransposeWorldViewMatrix[0].xyz, u_inverseTransposeWorldViewMatrix[1].xyz, u_inverseTransposeWorldViewMatrix[2].xyz);
+    mat3 normalMatrix = mat3(u_inverseTransposeWorldMatrix[0].xyz, u_inverseTransposeWorldMatrix[1].xyz, u_inverseTransposeWorldMatrix[2].xyz);
     v_normalVector = normalMatrix * normal;
 
     // Apply light.


### PR DESCRIPTION
Fixes #554
Fixes #561

Note: Causes backward compat. issues for lit objects using shader library in materials bindings.

To fix: Change your material bindings
from:
u_inverseTransposeWorldViewMatrix = INVERSE_TRANSPOSE_WORLD_VIEW_MATRIX
to:
u_inverseTransposeWorldMatrix = INVERSE_TRANSPOSE_WORLD_MATRIX
