### PR TITLE
Linux platform fix for crash on game exit / window destroy

### DIFF
--- a/gameplay/src/PlatformLinux.cpp
+++ b/gameplay/src/PlatformLinux.cpp
@@ -624,8 +624,8 @@ int Platform::enterMessagePump()
                     {
                         _game->exit();
                     }
-                    break;
                 }
+                break;
             case DestroyNotify :
                 {
                     cleanupX11();


### PR DESCRIPTION
Game loop was not broken out of on Game::exit(), resulting in a crash as the next update was on objects that were already released.

Also, DestroyNotify event is not sent when the window is closed if the window was remapped by the window manager (remapping is what happens when all the window decorations are added by the WM). When WM closed the window, there was no code cleanup (Game::finalize()), fixed with the WM_DESTROY_WINDOW client message.
