### PR TITLE
Fixed compile error in PlatformMacOSX.mm.

### DIFF
--- a/gameplay/src/PlatformMacOSX.mm
+++ b/gameplay/src/PlatformMacOSX.mm
@@ -1899,6 +1899,4 @@ bool Platform::launchUrl(const char *url)
     return (err == noErr);
 }
 
-}
-
 #endif


### PR DESCRIPTION
Related to Platform::launchUrl()
