### PR TITLE
operator overload for cross-products.

### DIFF
--- a/gameplay/src/Vector3.h
+++ b/gameplay/src/Vector3.h
@@ -424,6 +424,16 @@ public:
      * @return The scaled vector.
      */
     inline const Vector3 operator*(float x) const;
+    
+    /**
+     * Returns the components of this vector divided by the given constant
+     *
+     * Note: this does not modify this vector.
+     *
+     * @param x the constant to divide this vector with
+     * @return a smaller vector
+     */
+    inline const Vector3 operator/(float x) const;
 
     /**
      * Scales this vector by the given value.

--- a/gameplay/src/Vector3.inl
+++ b/gameplay/src/Vector3.inl
@@ -57,6 +57,11 @@ inline Vector3& Vector3::operator*=(float x)
     return *this;
 }
 
+inline const Vector3 Vector3::operator/(const float x) const
+{
+    return Vector3(this->x / x, this->y / x, this->z / x);
+}
+
 inline bool Vector3::operator<(const Vector3& v) const
 {
     if (x == v.x)


### PR DESCRIPTION
Overloads the '*' operator of vector3 such that "a \* b" returns a new vector3 that is the equivalent to a.cross(b), but does not modify a.
