### PR TITLE
Scalar division with the '/' operator on vectors.

### DIFF
--- a/gameplay/src/Vector2.h
+++ b/gameplay/src/Vector2.h
@@ -392,6 +392,16 @@ public:
      * @return This vector, after the scale occurs.
      */
     inline Vector2& operator*=(float x);
+    
+    /**
+     * Returns the components of this vector divided by the given constant
+     *
+     * Note: this does not modify this vector.
+     *
+     * @param x the constant to divide this vector with
+     * @return a smaller vector
+     */
+    inline const Vector2 operator/(float x) const;
 
     /**
      * Determines if this vector is less than the given vector.

--- a/gameplay/src/Vector2.inl
+++ b/gameplay/src/Vector2.inl
@@ -49,6 +49,11 @@ inline Vector2& Vector2::operator*=(float x)
     return *this;
 }
 
+inline const Vector2 Vector2::operator/(const float x) const
+{
+    return Vector2(this->x / x, this->y / x);
+}
+
 inline bool Vector2::operator<(const Vector2& v) const
 {
     if (x == v.x)

--- a/gameplay/src/Vector3.h
+++ b/gameplay/src/Vector3.h
@@ -404,16 +404,6 @@ public:
      * @return The negation of this vector.
      */
     inline const Vector3 operator-() const;
-    
-    /**
-     * Returns the cross product of this vector and the given vector
-     *
-     * Note: this does not modify this vector.
-     *
-     * @param v the vector to cross against
-     * @return the cross product
-     */
-    inline const Vector3 operator*(const Vector3& v) const;
 
     /**
      * Calculates the scalar product of this vector with the given value.
@@ -424,6 +414,14 @@ public:
      * @return The scaled vector.
      */
     inline const Vector3 operator*(float x) const;
+
+    /**
+     * Scales this vector by the given value.
+     * 
+     * @param x The value to scale by.
+     * @return This vector, after the scale occurs.
+     */
+    inline Vector3& operator*=(float x);
     
     /**
      * Returns the components of this vector divided by the given constant
@@ -434,14 +432,6 @@ public:
      * @return a smaller vector
      */
     inline const Vector3 operator/(float x) const;
-
-    /**
-     * Scales this vector by the given value.
-     * 
-     * @param x The value to scale by.
-     * @return This vector, after the scale occurs.
-     */
-    inline Vector3& operator*=(float x);
 
     /**
      * Determines if this vector is less than the given vector.

--- a/gameplay/src/Vector3.inl
+++ b/gameplay/src/Vector3.inl
@@ -37,13 +37,6 @@ inline const Vector3 Vector3::operator-() const
     return result;
 }
 
-inline const Vector3 Vector3::operator*(const Vector3& v) const
-{
-    Vector3 result(*this);
-    result.cross(v);
-    return result;
-}
-
 inline const Vector3 Vector3::operator*(float x) const
 {
     Vector3 result(*this);

--- a/gameplay/src/Vector4.h
+++ b/gameplay/src/Vector4.h
@@ -404,6 +404,16 @@ public:
      * @return This vector, after the scale occurs.
      */
     inline Vector4& operator*=(float x);
+    
+    /**
+     * Returns the components of this vector divided by the given constant
+     *
+     * Note: this does not modify this vector.
+     *
+     * @param x the constant to divide this vector with
+     * @return a smaller vector
+     */
+    inline const Vector4 operator/(float x) const;
 
     /**
      * Determines if this vector is less than the given vector.

--- a/gameplay/src/Vector4.inl
+++ b/gameplay/src/Vector4.inl
@@ -50,6 +50,11 @@ inline Vector4& Vector4::operator*=(float x)
     return *this;
 }
 
+inline const Vector4 Vector4::operator/(const float x) const
+{
+    return Vector4(this->x / x, this->y / x, this->z / x, this->w / x);
+}
+
 inline bool Vector4::operator<(const Vector4& v) const
 {
     if (x == v.x)


### PR DESCRIPTION
Followup from https://github.com/blackberry/GamePlay/pull/834,

You can ignore commit 175a8e5, it was rolled back, as per my earlier rejected pull request.

Commit c3561f2 is just the '/' operator applied only to Vector3, and the last one extends that operator to Vector4 and Vector2.

Thanks.
