### PR TITLE
Fixed userData pointer not cloned when cloning a node.

### DIFF
--- a/gameplay/src/Node.cpp
+++ b/gameplay/src/Node.cpp
@@ -1003,6 +1003,7 @@ void Node::cloneInto(Node* node, NodeCloneContext &context) const
     }
     node->_world = _world;
     node->_bounds = _bounds;
+    node->_userData = _userData;
     if (_tags)
     {
         node->_tags = new std::map<std::string, std::string>(_tags->begin(), _tags->end());


### PR DESCRIPTION
When cloning a Node it's userData pointer was not set on the cloned node.
