### PR TITLE
Gamepad support for Linux

### DIFF
--- a/gameplay/src/PlatformLinux.cpp
+++ b/gameplay/src/PlatformLinux.cpp
@@ -18,7 +18,6 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>
-#include <usb.h>
 #include <fstream>
 
 #define TOUCH_COUNT_MAX     4


### PR DESCRIPTION
Supporting gamepad for linux. Have made mappings for PS3 SixAxis & DragonRise Gamepads and tested. Copied Xbox360 mappings from the mac code but i never tested it because i don't have the gamepad. I think the next step would be making some generic way to handle mappings between platforms (The mappings for the linux port are to some extent data driven. Made it like that to try doing generic mapping structure as much as possible).

I might add udev support. udev should be used as a base component in many modern disto
ros. I will make it optional so if the developer have that libudev-dev package installed the engine will use it.  I don't know the licensing stuff if we used that lib and linked againest it (i think it is GPL2). But right now the code is using the standard kernel headers ("/linux/joystick.h").

It also contains a fix for CMake sample files on archlinux because of a linker error that pthread is not defined.

Tested on Archlinux with kernel 3.6.3 and Ubuntu 12.10 x64.
