### PR TITLE
const qualifiers on MeshBatch::add arguments

### DIFF
--- a/gameplay/src/MeshBatch.cpp
+++ b/gameplay/src/MeshBatch.cpp
@@ -43,7 +43,7 @@ MeshBatch* MeshBatch::create(const VertexFormat& vertexFormat, Mesh::PrimitiveTy
     return batch;
 }
 
-void MeshBatch::add(const void* vertices, size_t size, unsigned int vertexCount, unsigned short* indices, unsigned int indexCount)
+void MeshBatch::add(const void* vertices, size_t size, unsigned int vertexCount, const unsigned short* indices, unsigned int indexCount)
 {
     GP_ASSERT(vertices);
     
@@ -217,7 +217,7 @@ bool MeshBatch::resize(unsigned int capacity)
     return true;
 }
 
-void MeshBatch::add(const float* vertices, unsigned int vertexCount, unsigned short* indices, unsigned int indexCount)
+void MeshBatch::add(const float* vertices, unsigned int vertexCount, const unsigned short* indices, unsigned int indexCount)
 {
     add(vertices, sizeof(float), vertexCount, indices, indexCount);
 }

--- a/gameplay/src/MeshBatch.h
+++ b/gameplay/src/MeshBatch.h
@@ -91,7 +91,7 @@ public:
      * @param indexCount Number of indices (should be zero for non-indexed batches).
      */
     template <class T>
-    void add(const T* vertices, unsigned int vertexCount, unsigned short* indices = NULL, unsigned int indexCount = 0);
+    void add(const T* vertices, unsigned int vertexCount, const unsigned short* indices = NULL, unsigned int indexCount = 0);
 
     /**
      * Adds a group of primitives to the batch.
@@ -112,7 +112,7 @@ public:
      * @param indices Array of indices into the vertex array (should be NULL for non-indexed batches).
      * @param indexCount Number of indices (should be zero for non-indexed batches).
      */
-    void add(const float* vertices, unsigned int vertexCount, unsigned short* indices = NULL, unsigned int indexCount = 0);
+    void add(const float* vertices, unsigned int vertexCount, const unsigned short* indices = NULL, unsigned int indexCount = 0);
 
     /**
      * Starts batching.
@@ -153,7 +153,7 @@ private:
      */
     MeshBatch& operator=(const MeshBatch&);
 
-    void add(const void* vertices, size_t size, unsigned int vertexCount, unsigned short* indices, unsigned int indexCount);
+    void add(const void* vertices, size_t size, unsigned int vertexCount, const unsigned short* indices, unsigned int indexCount);
 
     void updateVertexAttributeBinding();
 

--- a/gameplay/src/MeshBatch.inl
+++ b/gameplay/src/MeshBatch.inl
@@ -9,7 +9,7 @@ Material* MeshBatch::getMaterial() const
 }
 
 template <class T>
-void MeshBatch::add(const T* vertices, unsigned int vertexCount, unsigned short* indices, unsigned int indexCount)
+void MeshBatch::add(const T* vertices, unsigned int vertexCount, const unsigned short* indices, unsigned int indexCount)
 {
     GP_ASSERT(sizeof(T) == _vertexFormat.getVertexSize());
     add(vertices, sizeof(T), vertexCount, indices, indexCount);


### PR DESCRIPTION
Since MeshBatch::add doesn't modify incoming vertices and indices, it's better to use const qualifier on these arguments. In this case MeshBatch::add could also be called from const-methods. Suppose, for example, the following method definition:

``` C++
void Foo::Render( ) const
{
    _meshBatch->add( &( *_vertices.begin( ) ), _vertices.size( ) );
}
```

where _vertices is of type std::vector and is a member of Foo. Without const qualifier on MeshBatch::add's arguments this code fragment will require const_cast on _vertices.begin( )
