### PR TITLE
Fixes unsupported framebuffer issue with  qualcomm's android driver.

### DIFF
--- a/gameplay/src/DepthStencilTarget.cpp
+++ b/gameplay/src/DepthStencilTarget.cpp
@@ -14,7 +14,7 @@ namespace gameplay
 static std::vector<DepthStencilTarget*> __depthStencilTargets;
 
 DepthStencilTarget::DepthStencilTarget(const char* id, Format format, unsigned int width, unsigned int height)
-    : _id(id ? id : ""), _format(format), _depthBuffer(0), _stencilBuffer(0), _width(width), _height(height)
+    : _id(id ? id : ""), _format(format), _depthBuffer(0), _stencilBuffer(0), _width(width), _height(height), _packed(false)
 {
 }
 
@@ -55,6 +55,7 @@ DepthStencilTarget* DepthStencilTarget::create(const char* id, Format format, un
         if (strstr(extString, "GL_OES_packed_depth_stencil") != 0)
         {
             GL_ASSERT( glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8_OES, width, height) );
+            depthStencilTarget->_packed = true;
         }
         else
         {
@@ -74,6 +75,12 @@ DepthStencilTarget* DepthStencilTarget::create(const char* id, Format format, un
             }
         }
     }
+    else
+    {
+        // Packed format GL_DEPTH24_STENCIL8 is used mark format as packed.
+        depthStencilTarget->_packed = true;
+    }
+
     // Add it to the cache.
     __depthStencilTargets.push_back(depthStencilTarget);
 
@@ -118,4 +125,8 @@ unsigned int DepthStencilTarget::getHeight() const
     return _height;
 }
 
+bool DepthStencilTarget::isPacked() const
+{
+    return _packed;
+}
 }

--- a/gameplay/src/DepthStencilTarget.h
+++ b/gameplay/src/DepthStencilTarget.h
@@ -82,6 +82,13 @@ public:
      */
     unsigned int getHeight() const;
 
+    /**
+     * Returns true if depth and stencil buffer are packed.
+     *
+     * @return The packed state.
+     */
+    bool isPacked() const;
+
 private:
 
     /**
@@ -105,6 +112,7 @@ private:
     RenderBufferHandle _stencilBuffer;
     unsigned int _width;
     unsigned int _height;
+    bool _packed;
 };
 
 }

--- a/gameplay/src/FrameBuffer.cpp
+++ b/gameplay/src/FrameBuffer.cpp
@@ -219,7 +219,11 @@ void FrameBuffer::setDepthStencilTarget(DepthStencilTarget* target)
 
         // Attach the render buffer to the framebuffer
         GL_ASSERT( glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, _depthStencilTarget->_depthBuffer) );
-        if (target->getFormat() == DepthStencilTarget::DEPTH_STENCIL)
+        if (target->isPacked())
+        {
+            GL_ASSERT( glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, _depthStencilTarget->_depthBuffer) );
+        }
+        else if (target->getFormat() == DepthStencilTarget::DEPTH_STENCIL)
         {
             GL_ASSERT( glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, _depthStencilTarget->_stencilBuffer) );
         }


### PR DESCRIPTION
When DepthStencilTargets are created using GL_DEPTH24_STENCIL8_OES
the same render buffer has to be used as depth and stencil attachment.

It seems that other driver implementations are not as restrictive as
qualcomm's and allow different renderbuffers. On tested Qualcomm Adreno
200 and 320 android devices however this resulted in an unsupported
Framebuffer.

Issue is fixed by setting a flag whether or not the DepthStencilTarget
uses an packed format. This flag is considered when attaching renderbuffers.
