### PR TITLE
Fixing ImageControl.o reference on linkage step.

### DIFF
--- a/gameplay/android/jni/Android.mk
+++ b/gameplay/android/jni/Android.mk
@@ -54,6 +54,7 @@ LOCAL_SRC_FILES := \
     Gamepad.cpp \
     HeightField.cpp \
     Image.cpp \
+	ImageControl.cpp \
     Joint.cpp \
     Joystick.cpp \
     Label.cpp \


### PR DESCRIPTION
Fixing compilation of android samples, leaking the last ImageControl.o
