### PR TITLE
Fixing upside-down "full image" UVs used as defaults.

### DIFF
--- a/gameplay/src/Theme.cpp
+++ b/gameplay/src/Theme.cpp
@@ -509,7 +509,7 @@ const Theme::UVs& Theme::UVs::empty()
 
 const Theme::UVs& Theme::UVs::full()
 {
-    static UVs full(0, 0, 1, 1);
+    static UVs full(0, 1, 1, 0);
     return full;
 }
 


### PR DESCRIPTION
Fixes #915
