### PR TITLE
Fixes parent relationship for cloned passes and techniques 

### DIFF
--- a/gameplay/src/Pass.cpp
+++ b/gameplay/src/Pass.cpp
@@ -92,6 +92,7 @@ Pass* Pass::clone(Technique* technique, NodeCloneContext &context) const
     effect->addRef();
     Pass* pass = new Pass(getId(), technique, effect);
     RenderState::cloneInto(pass, context);
+    pass->_parent = technique;
     return pass;
 }
 

--- a/gameplay/src/Technique.cpp
+++ b/gameplay/src/Technique.cpp
@@ -65,6 +65,7 @@ Technique* Technique::clone(Material* material, NodeCloneContext &context) const
         technique->_passes.push_back(passCopy);
     }
     RenderState::cloneInto(technique, context);
+    technique->_parent = material;
     return technique;
 }
 


### PR DESCRIPTION
traversing the render states produced unintended results as the parent relationship of the original object was followed.
