### PR TITLE
Optional initialisation of controllers in Game constructor.

### DIFF
--- a/gameplay/src/AnimationClip.cpp
+++ b/gameplay/src/AnimationClip.cpp
@@ -620,8 +620,17 @@ AnimationClip* AnimationClip::clone(Animation* animation) const
 
 AnimationClip::ScriptListener::ScriptListener(const std::string& function)
 {
-    // Store the function name.
-    this->function = Game::getInstance()->getScriptController()->loadUrl(function.c_str());
+    ScriptController* sc = Game::getInstance()->getScriptController();
+    
+    if(sc)
+    {
+        // Store the function name.
+        this->function = sc->loadUrl(function.c_str());
+    }
+    else
+    {
+        GP_ERROR("ScriptController not initialized");
+    }
 }
 
 void AnimationClip::ScriptListener::animationEvent(AnimationClip* clip, EventType type)

--- a/gameplay/src/Game.h
+++ b/gameplay/src/Game.h
@@ -39,6 +39,20 @@ public:
         RUNNING,
         PAUSED
     };
+    
+    /**
+     * Define which controllers are used in constructor.
+     */
+    enum Controller
+    {
+        CONTROLLER_NONE = 0x0,
+        CONTROLLER_AI = 0x1,
+        CONTROLLER_ANIMATION = 0x2,
+        CONTROLLER_AUDIO = 0x04,
+        CONTROLLER_PHYSICS = 0x08,
+        CONTROLLER_SCRIPT = 0x10,
+        CONTROLLER_ALL = CONTROLLER_AI | CONTROLLER_ANIMATION | CONTROLLER_AUDIO | CONTROLLER_PHYSICS | CONTROLLER_SCRIPT
+    };
 
     /**
      * Flags used when clearing the active frame buffer targets.
@@ -529,8 +543,9 @@ protected:
 
     /**
      * Constructor.
+     * @param useController Specify the controllers that should be initialized. Default is CONTROLLER_ALL.
      */
-    Game();
+    Game(Controller useController = CONTROLLER_ALL);
 
     /**
      * Initialize callback that is called just before the first frame when the game starts.
@@ -684,6 +699,7 @@ private:
     std::priority_queue<TimeEvent, std::vector<TimeEvent>, std::less<TimeEvent> >* _timeEvents;     // Contains the scheduled time events.
     ScriptController* _scriptController;            // Controls the scripting engine.
     std::vector<ScriptListener*>* _scriptListeners; // Lua script listeners.
+    Controller _useController;
 
     // Note: Do not add STL object member variables on the stack; this will cause false memory leaks to be reported.
 

--- a/gameplay/src/Logger.cpp
+++ b/gameplay/src/Logger.cpp
@@ -61,7 +61,12 @@ void Logger::log(Level level, const char* message, ...)
     else if (state.logFunctionLua)
     {
         // Pass call to registered Lua log function
-        Game::getInstance()->getScriptController()->executeFunction<void>(state.logFunctionLua, "[Logger::Level]s", level, str);
+        ScriptController* sc = Game::getInstance()->getScriptController();
+        
+        if(sc)
+        {
+            sc->executeFunction<void>(state.logFunctionLua, "[Logger::Level]s", level, str);
+        }
     }
     else
     {

--- a/gameplay/src/PhysicsCollisionObject.cpp
+++ b/gameplay/src/PhysicsCollisionObject.cpp
@@ -291,15 +291,33 @@ void PhysicsCollisionObject::PhysicsMotionState::setCenterOfMassOffset(const Vec
 PhysicsCollisionObject::ScriptListener::ScriptListener(const char* url)
     : url(url)
 {
-    function = Game::getInstance()->getScriptController()->loadUrl(url);
+    ScriptController* sc = Game::getInstance()->getScriptController();
+    
+    if(sc)
+    {
+        function = sc->loadUrl(url);
+    }
+    else
+    {
+        GP_ERROR("ScriptController not initialized");
+    }
 }
 
 void PhysicsCollisionObject::ScriptListener::collisionEvent(PhysicsCollisionObject::CollisionListener::EventType type,
     const PhysicsCollisionObject::CollisionPair& collisionPair, const Vector3& contactPointA, const Vector3& contactPointB)
 {
-    Game::getInstance()->getScriptController()->executeFunction<void>(function.c_str(), 
+    ScriptController* sc = Game::getInstance()->getScriptController();
+    
+    if(sc)
+    {
+        Game::getInstance()->getScriptController()->executeFunction<void>(function.c_str(), 
         "[PhysicsCollisionObject::CollisionListener::EventType]<PhysicsCollisionObject::CollisionPair><Vector3><Vector3>",
         type, &collisionPair, &contactPointA, &contactPointB);
+    }
+    else
+    {
+        GP_ERROR("ScriptController not initialized");
+    }
 }
 
 }

--- a/gameplay/src/PlatformAndroid.cpp
+++ b/gameplay/src/PlatformAndroid.cpp
@@ -1236,7 +1236,13 @@ void Platform::touchEventInternal(Touch::TouchEvent evt, int x, int y, unsigned 
     if (!Form::touchEventInternal(evt, x, y, contactIndex))
     {
         Game::getInstance()->touchEvent(evt, x, y, contactIndex);
-        Game::getInstance()->getScriptController()->touchEvent(evt, x, y, contactIndex);
+        
+        ScriptController* sc = Game::getInstance()->getScriptController();
+        
+        if(sc)
+        {
+            sc->touchEvent(evt, x, y, contactIndex);
+        }
     }
 }
 
@@ -1245,7 +1251,13 @@ void Platform::keyEventInternal(Keyboard::KeyEvent evt, int key)
     if (!Form::keyEventInternal(evt, key))
     {
         Game::getInstance()->keyEvent(evt, key);
-        Game::getInstance()->getScriptController()->keyEvent(evt, key);
+        
+        ScriptController* sc = Game::getInstance()->getScriptController();
+        
+        if(sc)
+        {
+            sc->keyEvent(evt, key);
+        }
     }
 }
 
@@ -1261,7 +1273,16 @@ bool Platform::mouseEventInternal(Mouse::MouseEvent evt, int x, int y, int wheel
     }
     else
     {
-        return Game::getInstance()->getScriptController()->mouseEvent(evt, x, y, wheelDelta);
+        ScriptController* sc = Game::getInstance()->getScriptController();
+        
+        if(sc)
+        {
+            return sc->mouseEvent(evt, x, y, wheelDelta);
+        }
+        else
+        {
+            return false;
+        }
     }
 }
 

--- a/gameplay/src/PlatformBlackBerry.cpp
+++ b/gameplay/src/PlatformBlackBerry.cpp
@@ -1492,7 +1492,13 @@ void Platform::touchEventInternal(Touch::TouchEvent evt, int x, int y, unsigned 
     if (!Form::touchEventInternal(evt, x, y, contactIndex))
     {
         Game::getInstance()->touchEvent(evt, x, y, contactIndex);
-        Game::getInstance()->getScriptController()->touchEvent(evt, x, y, contactIndex);
+        
+        ScriptController* sc = Game::getInstance()->getScriptController();
+        
+        if(sc)
+        {
+            sc->touchEvent(evt, x, y, contactIndex);
+        }
     }
 }
 
@@ -1501,7 +1507,13 @@ void Platform::keyEventInternal(Keyboard::KeyEvent evt, int key)
     if (!Form::keyEventInternal(evt, key))
     {
         Game::getInstance()->keyEvent(evt, key);
-        Game::getInstance()->getScriptController()->keyEvent(evt, key);
+        
+        ScriptController* sc = Game::getInstance()->getScriptController();
+        
+        if(sc)
+        {
+            sc->keyEvent(evt, key);
+        }
     }
 }
 
@@ -1517,7 +1529,16 @@ bool Platform::mouseEventInternal(Mouse::MouseEvent evt, int x, int y, int wheel
     }
     else
     {
-        return Game::getInstance()->getScriptController()->mouseEvent(evt, x, y, wheelDelta);
+        ScriptController* sc = Game::getInstance()->getScriptController();
+        
+        if(sc)
+        {
+            return sc->mouseEvent(evt, x, y, wheelDelta);
+        }
+        else
+        {
+            return false;
+        }
     }
 }
 

--- a/gameplay/src/PlatformLinux.cpp
+++ b/gameplay/src/PlatformLinux.cpp
@@ -1094,7 +1094,13 @@ void Platform::touchEventInternal(Touch::TouchEvent evt, int x, int y, unsigned 
     if (!Form::touchEventInternal(evt, x, y, contactIndex))
     {
         Game::getInstance()->touchEvent(evt, x, y, contactIndex);
-        Game::getInstance()->getScriptController()->touchEvent(evt, x, y, contactIndex);
+        
+        ScriptController* sc = Game::getInstance()->getScriptController();
+        
+        if(sc)
+        {
+            sc->touchEvent(evt, x, y, contactIndex);
+        }
     }
 }
 
@@ -1103,7 +1109,13 @@ void Platform::keyEventInternal(Keyboard::KeyEvent evt, int key)
     if (!Form::keyEventInternal(evt, key))
     {
         Game::getInstance()->keyEvent(evt, key);
-        Game::getInstance()->getScriptController()->keyEvent(evt, key);
+
+        ScriptController* sc = Game::getInstance()->getScriptController();
+        
+        if(sc)
+        {
+            sc->getScriptController()->keyEvent(evt, key);
+        }
     }
 }
 
@@ -1119,7 +1131,16 @@ bool Platform::mouseEventInternal(Mouse::MouseEvent evt, int x, int y, int wheel
     }
     else
     {
-        return Game::getInstance()->getScriptController()->mouseEvent(evt, x, y, wheelDelta);
+        ScriptController* sc = Game::getInstance()->getScriptController();
+        
+        if(sc)
+        {
+            return sc->mouseEvent(evt, x, y, wheelDelta);
+        }
+        else
+        {
+            return false;
+        }
     }
 }
 

--- a/gameplay/src/PlatformMacOSX.mm
+++ b/gameplay/src/PlatformMacOSX.mm
@@ -1730,7 +1730,13 @@ void Platform::touchEventInternal(Touch::TouchEvent evt, int x, int y, unsigned 
     if (!Form::touchEventInternal(evt, x, y, contactIndex))
     {
         Game::getInstance()->touchEvent(evt, x, y, contactIndex);
-        Game::getInstance()->getScriptController()->touchEvent(evt, x, y, contactIndex);
+        
+        ScriptController* sc = Game::getInstance()->getScriptController();
+        
+        if(sc)
+        {
+            sc->touchEvent(evt, x, y, contactIndex);
+        }
     }
     [__view->gameLock unlock];
 }
@@ -1741,7 +1747,13 @@ void Platform::keyEventInternal(Keyboard::KeyEvent evt, int key)
     if (!Form::keyEventInternal(evt, key))
     {
         Game::getInstance()->keyEvent(evt, key);
-        Game::getInstance()->getScriptController()->keyEvent(evt, key);
+        
+        ScriptController* sc = Game::getInstance()->getScriptController();
+        
+        if(sc)
+        {
+            sc->keyEvent(evt, key);
+        }
     }
     [__view->gameLock unlock];
 }
@@ -1761,7 +1773,16 @@ bool Platform::mouseEventInternal(Mouse::MouseEvent evt, int x, int y, int wheel
     }
     else
     {
-        result = Game::getInstance()->getScriptController()->mouseEvent(evt, x, y, wheelDelta);
+        ScriptController* sc = Game::getInstance()->getScriptController();
+        
+        if(sc)
+        {
+            result = sc->mouseEvent(evt, x, y, wheelDelta);
+        }
+        else
+        {
+            result = false;
+        }
     }
     
     [__view->gameLock unlock];

--- a/gameplay/src/PlatformWindows.cpp
+++ b/gameplay/src/PlatformWindows.cpp
@@ -1252,7 +1252,13 @@ void Platform::touchEventInternal(Touch::TouchEvent evt, int x, int y, unsigned 
     if (!Form::touchEventInternal(evt, x, y, contactIndex))
     {
         Game::getInstance()->touchEvent(evt, x, y, contactIndex);
-        Game::getInstance()->getScriptController()->touchEvent(evt, x, y, contactIndex);
+        
+        ScriptController* sc = Game::getInstance()->getScriptController();
+        
+        if(sc)
+        {
+            sc->touchEvent(evt, x, y, contactIndex);
+        }
     }
 }
 
@@ -1261,7 +1267,13 @@ void Platform::keyEventInternal(Keyboard::KeyEvent evt, int key)
     if (!Form::keyEventInternal(evt, key))
     {
         Game::getInstance()->keyEvent(evt, key);
-        Game::getInstance()->getScriptController()->keyEvent(evt, key);
+        
+        ScriptController* sc = Game::getInstance()->getScriptController();
+        
+        if(sc)
+        {
+            sc->keyEvent(evt, key);
+        }
     }
 }
 
@@ -1277,7 +1289,16 @@ bool Platform::mouseEventInternal(Mouse::MouseEvent evt, int x, int y, int wheel
     }
     else
     {
-        return Game::getInstance()->getScriptController()->mouseEvent(evt, x, y, wheelDelta);
+        ScriptController* sc = Game::getInstance()->getScriptController();
+        
+        if(sc)
+        {
+            return sc->mouseEvent(evt, x, y, wheelDelta);
+        }
+        else
+        {
+            return false;
+        }
     }
 }
 

--- a/gameplay/src/PlatformiOS.mm
+++ b/gameplay/src/PlatformiOS.mm
@@ -1438,7 +1438,13 @@ void Platform::touchEventInternal(Touch::TouchEvent evt, int x, int y, unsigned 
     if (!Form::touchEventInternal(evt, x, y, contactIndex))
     {
         Game::getInstance()->touchEvent(evt, x, y, contactIndex);
-        Game::getInstance()->getScriptController()->touchEvent(evt, x, y, contactIndex);
+        
+        ScriptController* sc = Game::getInstance()->getScriptController();
+        
+        if(sc)
+        {
+            sc->touchEvent(evt, x, y, contactIndex);
+        }
     }
 }
     
@@ -1447,7 +1453,13 @@ void Platform::keyEventInternal(Keyboard::KeyEvent evt, int key)
     if (!Form::keyEventInternal(evt, key))
     {
         Game::getInstance()->keyEvent(evt, key);
-        Game::getInstance()->getScriptController()->keyEvent(evt, key);
+        
+        ScriptController* sc = Game::getInstance()->getScriptController();
+        
+        if(sc)
+        {
+            sc->keyEvent(evt, key);
+        }
     }
 }
 
@@ -1463,7 +1475,16 @@ bool Platform::mouseEventInternal(Mouse::MouseEvent evt, int x, int y, int wheel
     }
     else
     {
-        return Game::getInstance()->getScriptController()->mouseEvent(evt, x, y, wheelDelta);
+        ScriptController* sc = Game::getInstance()->getScriptController();
+        
+        if(sc)
+        {
+            return sc->mouseEvent(evt, x, y, wheelDelta);
+        }
+        else
+        {
+            return false;
+        }
     }
 }
 

--- a/gameplay/src/Scene.h
+++ b/gameplay/src/Scene.h
@@ -405,6 +405,12 @@ void Scene::visitNode(Node* node, T* instance, bool (T::*visitMethod)(Node*,C), 
 inline void Scene::visitNode(Node* node, const char* visitMethod)
 {
     ScriptController* sc = Game::getInstance()->getScriptController();
+    
+    if(!sc)
+    {
+        GP_ERROR("ScriptController not initialized");
+        return;
+    }
 
     // Invoke the visit method for this node.
     if (!sc->executeFunction<bool>(visitMethod, "<Node>", node))

--- a/gameplay/src/ScriptController.cpp
+++ b/gameplay/src/ScriptController.cpp
@@ -65,8 +65,14 @@ void ScriptUtil::registerLibrary(const char* name, const luaL_Reg* functions)
 void ScriptUtil::registerConstantBool(const std::string& name, bool value, const std::vector<std::string>& scopePath)
 {
     ScriptController* sc = Game::getInstance()->getScriptController();
+    
+    if(!sc)
+    {
+        GP_ERROR("ScriptController not initialized");
+        return;
+    }
 
-    // If the constant is within a scope, get the correct parent 
+    // If the constant is within a scope, get the correct parent
     // table on the stack before setting its value.
     if (!scopePath.empty())
     {
@@ -98,6 +104,12 @@ void ScriptUtil::registerConstantBool(const std::string& name, bool value, const
 void ScriptUtil::registerConstantNumber(const std::string& name, double value, const std::vector<std::string>& scopePath)
 {
     ScriptController* sc = Game::getInstance()->getScriptController();
+    
+    if(!sc)
+    {
+        GP_ERROR("ScriptController not initialized");
+        return;
+    }
 
     // If the constant is within a scope, get the correct parent 
     // table on the stack before setting its value.
@@ -132,6 +144,12 @@ void ScriptUtil::registerConstantString(const std::string& name, const std::stri
 {
     ScriptController* sc = Game::getInstance()->getScriptController();
 
+    if(!sc)
+    {
+        GP_ERROR("ScriptController not initialized");
+        return;
+    }
+
     // If the constant is within a scope, get the correct parent 
     // table on the stack before setting its value.
     if (!scopePath.empty())
@@ -165,6 +183,12 @@ void ScriptUtil::registerClass(const char* name, const luaL_Reg* members, lua_CF
     lua_CFunction deleteFunction, const luaL_Reg* statics,  const std::vector<std::string>& scopePath)
 {
     ScriptController* sc = Game::getInstance()->getScriptController();
+
+    if(!sc)
+    {
+        GP_ERROR("ScriptController not initialized");
+        return;
+    }
 
     // If the type is an inner type, get the correct parent 
     // table on the stack before creating the table for the class.
@@ -249,8 +273,16 @@ void ScriptUtil::registerClass(const char* name, const luaL_Reg* members, lua_CF
 
 void ScriptUtil::registerFunction(const char* luaFunction, lua_CFunction cppFunction)
 {
-    lua_pushcfunction(Game::getInstance()->getScriptController()->_lua, cppFunction);
-    lua_setglobal(Game::getInstance()->getScriptController()->_lua, luaFunction);
+    ScriptController* sc = Game::getInstance()->getScriptController();
+    
+    if(!sc)
+    {
+        GP_ERROR("ScriptController not initialized");
+        return;
+    }
+
+    lua_pushcfunction(sc->_lua, cppFunction);
+    lua_setglobal(sc->_lua, luaFunction);
 }
 
 void ScriptUtil::setGlobalHierarchyPair(const std::string& base, const std::string& derived)

--- a/gameplay/src/ScriptController.inl
+++ b/gameplay/src/ScriptController.inl
@@ -95,6 +95,12 @@ ScriptUtil::LuaArray<T> ScriptUtil::getObjectPointer(int index, const char* type
     *success = false;
 
     ScriptController* sc = Game::getInstance()->getScriptController();
+    
+    if(!sc)
+    {
+        GP_ERROR("ScriptController not initialized");
+        LuaArray<T>((T*)NULL);
+    }
 
     // Was 'nil' passed?
     if (lua_type(sc->_lua, index) == LUA_TNIL)

--- a/gameplay/src/ScriptTarget.cpp
+++ b/gameplay/src/ScriptTarget.cpp
@@ -30,19 +30,26 @@ template<> void ScriptTarget::fireScriptEvent<void>(const char* eventName, ...)
     {
         ScriptController* sc = Game::getInstance()->getScriptController();
 
-        if (_events[eventName].size() > 0)
+        if(sc)
         {
-            for (unsigned int i = 0; i < iter->second->size(); i++)
+            if (_events[eventName].size() > 0)
             {
-                sc->executeFunction<void>((*iter->second)[i].function.c_str(), _events[eventName].c_str(), &list);
+                for (unsigned int i = 0; i < iter->second->size(); i++)
+                {
+                    sc->executeFunction<void>((*iter->second)[i].function.c_str(), _events[eventName].c_str(), &list);
+                }
+            }
+            else
+            {
+                for (unsigned int i = 0; i < iter->second->size(); i++)
+                {
+                    sc->executeFunction<void>((*iter->second)[i].function.c_str(), _events[eventName].c_str());
+                }
             }
         }
         else
         {
-            for (unsigned int i = 0; i < iter->second->size(); i++)
-            {
-                sc->executeFunction<void>((*iter->second)[i].function.c_str(), _events[eventName].c_str());
-            }
+            GP_ERROR("ScriptController not initialized");
         }
     }
 
@@ -59,27 +66,34 @@ template<> bool ScriptTarget::fireScriptEvent<bool>(const char* eventName, ...)
     {
         ScriptController* sc = Game::getInstance()->getScriptController();
 
-        if (_events[eventName].size() > 0)
+        if(sc)
         {
-            for (unsigned int i = 0; i < iter->second->size(); i++)
+            if (_events[eventName].size() > 0)
             {
-                if (sc->executeFunction<bool>((*iter->second)[i].function.c_str(), _events[eventName].c_str(), &list))
+                for (unsigned int i = 0; i < iter->second->size(); i++)
                 {
-                    va_end(list);
-                    return true;
+                    if (sc->executeFunction<bool>((*iter->second)[i].function.c_str(), _events[eventName].c_str(), &list))
+                    {
+                        va_end(list);
+                        return true;
+                    }
+                }
+            }
+            else
+            {
+                for (unsigned int i = 0; i < iter->second->size(); i++)
+                {
+                    if (sc->executeFunction<bool>((*iter->second)[i].function.c_str(), _events[eventName].c_str()))
+                    {
+                        va_end(list);
+                        return true;
+                    }
                 }
             }
         }
         else
         {
-            for (unsigned int i = 0; i < iter->second->size(); i++)
-            {
-                if (sc->executeFunction<bool>((*iter->second)[i].function.c_str(), _events[eventName].c_str()))
-                {
-                    va_end(list);
-                    return true;
-                }
-            }
+            GP_ERROR("ScriptController not initialized");
         }
     }
 
@@ -89,6 +103,14 @@ template<> bool ScriptTarget::fireScriptEvent<bool>(const char* eventName, ...)
 
 void ScriptTarget::addScriptCallback(const std::string& eventName, const std::string& function)
 {
+    ScriptController* sc = Game::getInstance()->getScriptController();
+    
+    if(!sc)
+    {
+        GP_ERROR("ScriptController not initialized");
+        return;
+    }
+    
     std::map<std::string, std::vector<Callback>* >::iterator iter = _callbacks.find(eventName);
     if (iter != _callbacks.end())
     {


### PR DESCRIPTION
Controller usage is optional by specifying which to use in Game constructor, default is all.

Background:
http://www.gameplay3d.org/forums/viewtopic.php?f=4&t=493

Besides memory usage, I have my own OpenAL audio system running and the GamePlay AudioController creates a conflict.
