### PR TITLE
Fixed required libraries / frameworks don't exist when building a project

### DIFF
--- a/gameplay-template/gameplay-template.xcodeproj/project.pbxproj
+++ b/gameplay-template/gameplay-template.xcodeproj/project.pbxproj
@@ -7,13 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		42049B5816ADBB61005DD1F9 /* CoreMotion.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 42049B5216ADBB61005DD1F9 /* CoreMotion.framework */; };
-		42049B5916ADBB61005DD1F9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 42049B5316ADBB61005DD1F9 /* Foundation.framework */; };
-		42049B5A16ADBB61005DD1F9 /* OpenAL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 42049B5416ADBB61005DD1F9 /* OpenAL.framework */; };
-		42049B5B16ADBB61005DD1F9 /* OpenGLES.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 42049B5516ADBB61005DD1F9 /* OpenGLES.framework */; };
-		42049B5C16ADBB61005DD1F9 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 42049B5616ADBB61005DD1F9 /* QuartzCore.framework */; };
-		42049B5D16ADBB61005DD1F9 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 42049B5716ADBB61005DD1F9 /* UIKit.framework */; };
-		42049B5F16ADBBF5005DD1F9 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 42049B5E16ADBBF5005DD1F9 /* libz.dylib */; };
+		1E89CB4E171B20DA00D3B4B4 /* CoreMotion.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E89CB4D171B20DA00D3B4B4 /* CoreMotion.framework */; };
+		1E89CB50171B20E000D3B4B4 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E89CB4F171B20E000D3B4B4 /* Foundation.framework */; };
+		1E89CB52171B20E300D3B4B4 /* OpenAL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E89CB51171B20E300D3B4B4 /* OpenAL.framework */; };
+		1E89CB54171B20EA00D3B4B4 /* OpenGLES.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E89CB53171B20EA00D3B4B4 /* OpenGLES.framework */; };
+		1E89CB56171B20EE00D3B4B4 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E89CB55171B20EE00D3B4B4 /* QuartzCore.framework */; };
+		1E89CB58171B20F200D3B4B4 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E89CB57171B20F200D3B4B4 /* UIKit.framework */; };
+		1E89CB62171B219A00D3B4B4 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E89CB61171B219A00D3B4B4 /* libz.dylib */; };
 		42049B6116ADBC0F005DD1F9 /* libbullet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 42049B6016ADBC0F005DD1F9 /* libbullet.a */; };
 		42049B6316ADBC30005DD1F9 /* libbullet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 42049B6216ADBC30005DD1F9 /* libbullet.a */; };
 		42049B6516ADBC47005DD1F9 /* liblua.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 42049B6416ADBC47005DD1F9 /* liblua.a */; };
@@ -47,13 +47,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		42049B5216ADBB61005DD1F9 /* CoreMotion.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMotion.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.0.sdk/System/Library/Frameworks/CoreMotion.framework; sourceTree = DEVELOPER_DIR; };
-		42049B5316ADBB61005DD1F9 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		42049B5416ADBB61005DD1F9 /* OpenAL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenAL.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.0.sdk/System/Library/Frameworks/OpenAL.framework; sourceTree = DEVELOPER_DIR; };
-		42049B5516ADBB61005DD1F9 /* OpenGLES.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGLES.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.0.sdk/System/Library/Frameworks/OpenGLES.framework; sourceTree = DEVELOPER_DIR; };
-		42049B5616ADBB61005DD1F9 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.0.sdk/System/Library/Frameworks/QuartzCore.framework; sourceTree = DEVELOPER_DIR; };
-		42049B5716ADBB61005DD1F9 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.0.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
-		42049B5E16ADBBF5005DD1F9 /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.0.sdk/usr/lib/libz.dylib; sourceTree = DEVELOPER_DIR; };
+		1E89CB4D171B20DA00D3B4B4 /* CoreMotion.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMotion.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.1.sdk/System/Library/Frameworks/CoreMotion.framework; sourceTree = DEVELOPER_DIR; };
+		1E89CB4F171B20E000D3B4B4 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.1.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		1E89CB51171B20E300D3B4B4 /* OpenAL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenAL.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.1.sdk/System/Library/Frameworks/OpenAL.framework; sourceTree = DEVELOPER_DIR; };
+		1E89CB53171B20EA00D3B4B4 /* OpenGLES.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGLES.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.1.sdk/System/Library/Frameworks/OpenGLES.framework; sourceTree = DEVELOPER_DIR; };
+		1E89CB55171B20EE00D3B4B4 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.1.sdk/System/Library/Frameworks/QuartzCore.framework; sourceTree = DEVELOPER_DIR; };
+		1E89CB57171B20F200D3B4B4 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.1.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
+		1E89CB61171B219A00D3B4B4 /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.1.sdk/usr/lib/libz.dylib; sourceTree = DEVELOPER_DIR; };
 		42049B6016ADBC0F005DD1F9 /* libbullet.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libbullet.a; path = "GAMEPLAY_PATH/external-deps/bullet/lib/ios/armv7/libbullet.a"; sourceTree = "<group>"; };
 		42049B6216ADBC30005DD1F9 /* libbullet.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libbullet.a; path = "GAMEPLAY_PATH/external-deps/bullet/lib/macosx/libbullet.a"; sourceTree = "<group>"; };
 		42049B6416ADBC47005DD1F9 /* liblua.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = liblua.a; path = "GAMEPLAY_PATH/external-deps/lua/lib/macosx/liblua.a"; sourceTree = "<group>"; };
@@ -124,13 +124,13 @@
 				42049B7916ADBCC3005DD1F9 /* libvorbis.a in Frameworks */,
 				42049B7A16ADBCC3005DD1F9 /* libvorbisenc.a in Frameworks */,
 				42049B7B16ADBCC3005DD1F9 /* libvorbisfile.a in Frameworks */,
-				42049B5F16ADBBF5005DD1F9 /* libz.dylib in Frameworks */,
-				42049B5816ADBB61005DD1F9 /* CoreMotion.framework in Frameworks */,
-				42049B5916ADBB61005DD1F9 /* Foundation.framework in Frameworks */,
-				42049B5A16ADBB61005DD1F9 /* OpenAL.framework in Frameworks */,
-				42049B5B16ADBB61005DD1F9 /* OpenGLES.framework in Frameworks */,
-				42049B5C16ADBB61005DD1F9 /* QuartzCore.framework in Frameworks */,
-				42049B5D16ADBB61005DD1F9 /* UIKit.framework in Frameworks */,
+				1E89CB62171B219A00D3B4B4 /* libz.dylib in Frameworks */,
+				1E89CB58171B20F200D3B4B4 /* UIKit.framework in Frameworks */,
+				1E89CB56171B20EE00D3B4B4 /* QuartzCore.framework in Frameworks */,
+				1E89CB54171B20EA00D3B4B4 /* OpenGLES.framework in Frameworks */,
+				1E89CB52171B20E300D3B4B4 /* OpenAL.framework in Frameworks */,
+				1E89CB50171B20E000D3B4B4 /* Foundation.framework in Frameworks */,
+				1E89CB4E171B20DA00D3B4B4 /* CoreMotion.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -193,12 +193,12 @@
 		5B61613914CCC3560073B857 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
-				42049B5216ADBB61005DD1F9 /* CoreMotion.framework */,
-				42049B5316ADBB61005DD1F9 /* Foundation.framework */,
-				42049B5416ADBB61005DD1F9 /* OpenAL.framework */,
-				42049B5516ADBB61005DD1F9 /* OpenGLES.framework */,
-				42049B5616ADBB61005DD1F9 /* QuartzCore.framework */,
-				42049B5716ADBB61005DD1F9 /* UIKit.framework */,
+				1E89CB57171B20F200D3B4B4 /* UIKit.framework */,
+				1E89CB55171B20EE00D3B4B4 /* QuartzCore.framework */,
+				1E89CB53171B20EA00D3B4B4 /* OpenGLES.framework */,
+				1E89CB51171B20E300D3B4B4 /* OpenAL.framework */,
+				1E89CB4F171B20E000D3B4B4 /* Foundation.framework */,
+				1E89CB4D171B20DA00D3B4B4 /* CoreMotion.framework */,
 			);
 			name = iOS;
 			sourceTree = "<group>";
@@ -251,7 +251,7 @@
 				42049B7516ADBCC3005DD1F9 /* libvorbis.a */,
 				42049B7616ADBCC3005DD1F9 /* libvorbisenc.a */,
 				42049B7716ADBCC3005DD1F9 /* libvorbisfile.a */,
-				42049B5E16ADBBF5005DD1F9 /* libz.dylib */,
+				1E89CB61171B219A00D3B4B4 /* libz.dylib */,
 			);
 			name = iOS;
 			sourceTree = "<group>";

--- a/gameplay/gameplay.xcodeproj/project.pbxproj
+++ b/gameplay/gameplay.xcodeproj/project.pbxproj
@@ -7,6 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1E89CB3B171B1C8B00D3B4B4 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E89CB38171B1C7500D3B4B4 /* UIKit.framework */; };
+		1E89CB3C171B1C8B00D3B4B4 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E89CB36171B1C7000D3B4B4 /* QuartzCore.framework */; };
+		1E89CB3D171B1C8B00D3B4B4 /* OpenGLES.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E89CB34171B1C6900D3B4B4 /* OpenGLES.framework */; };
+		1E89CB3E171B1C8B00D3B4B4 /* OpenAL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E89CB32171B1C6300D3B4B4 /* OpenAL.framework */; };
+		1E89CB3F171B1C8B00D3B4B4 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E89CB30171B1C5E00D3B4B4 /* Foundation.framework */; };
+		1E89CB40171B1C8B00D3B4B4 /* CoreMotion.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E89CB2E171B1C5900D3B4B4 /* CoreMotion.framework */; };
+		1E89CB41171B1C9E00D3B4B4 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E89CB2C171B1C4B00D3B4B4 /* libz.dylib */; };
 		4201819014A41B18008C3F56 /* MeshBatch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4201818D14A41B18008C3F56 /* MeshBatch.cpp */; };
 		4201819114A41B18008C3F56 /* MeshBatch.h in Headers */ = {isa = PBXBuildFile; fileRef = 4201818E14A41B18008C3F56 /* MeshBatch.h */; };
 		4208DEE914A4079F00D3C511 /* Image.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4208DEE614A4079F00D3C511 /* Image.cpp */; };
@@ -836,13 +843,6 @@
 		42CD0EC8147D8FF60000361E /* VertexAttributeBinding.h in Headers */ = {isa = PBXBuildFile; fileRef = 42CD0E41147D8FF50000361E /* VertexAttributeBinding.h */; };
 		42CD0EC9147D8FF60000361E /* VertexFormat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 42CD0E42147D8FF50000361E /* VertexFormat.cpp */; };
 		42CD0ECA147D8FF60000361E /* VertexFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 42CD0E43147D8FF50000361E /* VertexFormat.h */; };
-		42DFAB5016AD8ECD0000F342 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 42DFAB4F16AD8ECD0000F342 /* libz.dylib */; };
-		42DFAB5A16AD8F310000F342 /* CoreMotion.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 42DFAB5316AD8F310000F342 /* CoreMotion.framework */; };
-		42DFAB5B16AD8F310000F342 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 42DFAB5416AD8F310000F342 /* Foundation.framework */; };
-		42DFAB5C16AD8F310000F342 /* OpenAL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 42DFAB5516AD8F310000F342 /* OpenAL.framework */; };
-		42DFAB5D16AD8F310000F342 /* OpenGLES.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 42DFAB5616AD8F310000F342 /* OpenGLES.framework */; };
-		42DFAB5E16AD8F310000F342 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 42DFAB5716AD8F310000F342 /* QuartzCore.framework */; };
-		42DFAB5F16AD8F310000F342 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 42DFAB5816AD8F310000F342 /* UIKit.framework */; };
 		42F4B7D715994CED00B5A78D /* Gamepad.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 42F4B7D515994CED00B5A78D /* Gamepad.cpp */; };
 		42F4B7D815994CED00B5A78D /* Gamepad.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 42F4B7D515994CED00B5A78D /* Gamepad.cpp */; };
 		42F4B7D915994CED00B5A78D /* Gamepad.h in Headers */ = {isa = PBXBuildFile; fileRef = 42F4B7D615994CED00B5A78D /* Gamepad.h */; };
@@ -1110,6 +1110,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		1E89CB2C171B1C4B00D3B4B4 /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.1.sdk/usr/lib/libz.dylib; sourceTree = DEVELOPER_DIR; };
+		1E89CB2E171B1C5900D3B4B4 /* CoreMotion.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMotion.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.1.sdk/System/Library/Frameworks/CoreMotion.framework; sourceTree = DEVELOPER_DIR; };
+		1E89CB30171B1C5E00D3B4B4 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.1.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		1E89CB32171B1C6300D3B4B4 /* OpenAL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenAL.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.1.sdk/System/Library/Frameworks/OpenAL.framework; sourceTree = DEVELOPER_DIR; };
+		1E89CB34171B1C6900D3B4B4 /* OpenGLES.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGLES.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.1.sdk/System/Library/Frameworks/OpenGLES.framework; sourceTree = DEVELOPER_DIR; };
+		1E89CB36171B1C7000D3B4B4 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.1.sdk/System/Library/Frameworks/QuartzCore.framework; sourceTree = DEVELOPER_DIR; };
+		1E89CB38171B1C7500D3B4B4 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.1.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		4201818D14A41B18008C3F56 /* MeshBatch.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MeshBatch.cpp; path = src/MeshBatch.cpp; sourceTree = SOURCE_ROOT; };
 		4201818E14A41B18008C3F56 /* MeshBatch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MeshBatch.h; path = src/MeshBatch.h; sourceTree = SOURCE_ROOT; };
 		4201818F14A41B18008C3F56 /* MeshBatch.inl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = MeshBatch.inl; path = src/MeshBatch.inl; sourceTree = SOURCE_ROOT; };
@@ -1620,13 +1627,6 @@
 		42CD0E41147D8FF50000361E /* VertexAttributeBinding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VertexAttributeBinding.h; path = src/VertexAttributeBinding.h; sourceTree = SOURCE_ROOT; };
 		42CD0E42147D8FF50000361E /* VertexFormat.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = VertexFormat.cpp; path = src/VertexFormat.cpp; sourceTree = SOURCE_ROOT; };
 		42CD0E43147D8FF50000361E /* VertexFormat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VertexFormat.h; path = src/VertexFormat.h; sourceTree = SOURCE_ROOT; };
-		42DFAB4F16AD8ECD0000F342 /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.0.sdk/usr/lib/libz.dylib; sourceTree = DEVELOPER_DIR; };
-		42DFAB5316AD8F310000F342 /* CoreMotion.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMotion.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.0.sdk/System/Library/Frameworks/CoreMotion.framework; sourceTree = DEVELOPER_DIR; };
-		42DFAB5416AD8F310000F342 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		42DFAB5516AD8F310000F342 /* OpenAL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenAL.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.0.sdk/System/Library/Frameworks/OpenAL.framework; sourceTree = DEVELOPER_DIR; };
-		42DFAB5616AD8F310000F342 /* OpenGLES.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGLES.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.0.sdk/System/Library/Frameworks/OpenGLES.framework; sourceTree = DEVELOPER_DIR; };
-		42DFAB5716AD8F310000F342 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.0.sdk/System/Library/Frameworks/QuartzCore.framework; sourceTree = DEVELOPER_DIR; };
-		42DFAB5816AD8F310000F342 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.0.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		42F4B7D515994CED00B5A78D /* Gamepad.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Gamepad.cpp; path = src/Gamepad.cpp; sourceTree = SOURCE_ROOT; };
 		42F4B7D615994CED00B5A78D /* Gamepad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Gamepad.h; path = src/Gamepad.h; sourceTree = SOURCE_ROOT; };
 		5B04C5CA14BFCFE100EB0071 /* libgameplay.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libgameplay.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1727,13 +1727,13 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				42DFAB5016AD8ECD0000F342 /* libz.dylib in Frameworks */,
-				42DFAB5A16AD8F310000F342 /* CoreMotion.framework in Frameworks */,
-				42DFAB5B16AD8F310000F342 /* Foundation.framework in Frameworks */,
-				42DFAB5C16AD8F310000F342 /* OpenAL.framework in Frameworks */,
-				42DFAB5D16AD8F310000F342 /* OpenGLES.framework in Frameworks */,
-				42DFAB5E16AD8F310000F342 /* QuartzCore.framework in Frameworks */,
-				42DFAB5F16AD8F310000F342 /* UIKit.framework in Frameworks */,
+				1E89CB41171B1C9E00D3B4B4 /* libz.dylib in Frameworks */,
+				1E89CB3B171B1C8B00D3B4B4 /* UIKit.framework in Frameworks */,
+				1E89CB3C171B1C8B00D3B4B4 /* QuartzCore.framework in Frameworks */,
+				1E89CB3D171B1C8B00D3B4B4 /* OpenGLES.framework in Frameworks */,
+				1E89CB3E171B1C8B00D3B4B4 /* OpenAL.framework in Frameworks */,
+				1E89CB3F171B1C8B00D3B4B4 /* Foundation.framework in Frameworks */,
+				1E89CB40171B1C8B00D3B4B4 /* CoreMotion.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2365,12 +2365,12 @@
 		5B04C5FD14BFE52300EB0071 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
-				42DFAB5316AD8F310000F342 /* CoreMotion.framework */,
-				42DFAB5416AD8F310000F342 /* Foundation.framework */,
-				42DFAB5516AD8F310000F342 /* OpenAL.framework */,
-				42DFAB5616AD8F310000F342 /* OpenGLES.framework */,
-				42DFAB5716AD8F310000F342 /* QuartzCore.framework */,
-				42DFAB5816AD8F310000F342 /* UIKit.framework */,
+				1E89CB38171B1C7500D3B4B4 /* UIKit.framework */,
+				1E89CB36171B1C7000D3B4B4 /* QuartzCore.framework */,
+				1E89CB34171B1C6900D3B4B4 /* OpenGLES.framework */,
+				1E89CB32171B1C6300D3B4B4 /* OpenAL.framework */,
+				1E89CB30171B1C5E00D3B4B4 /* Foundation.framework */,
+				1E89CB2E171B1C5900D3B4B4 /* CoreMotion.framework */,
 			);
 			name = iOS;
 			sourceTree = "<group>";
@@ -2397,7 +2397,7 @@
 				5B5DB93314C25BA5007755DB /* libvorbisenc.a */,
 				5B5DB93414C25BA5007755DB /* libvorbisfile.a */,
 				5B5DB92F14C25B94007755DB /* libpng.a */,
-				42DFAB4F16AD8ECD0000F342 /* libz.dylib */,
+				1E89CB2C171B1C4B00D3B4B4 /* libz.dylib */,
 			);
 			name = iOS;
 			sourceTree = "<group>";


### PR DESCRIPTION
Fixed required libraries/frameworks for Gameplay and a newly created project don't exist in which they require users to re-add them before building a project.
- Added required libraries/frameworks to gameplay project both iOS and Mac version.
- Added required libraries/frameworks to template project for iOS version (same libraries/frameworks as required by gameplay project).

See the screenshots below, there's no red out libraries/frameworks (except for libgameplay.a which is fine as I can't set it with template project alone). I tested building it on both iOS and Mac OS after applied fixes above, they both work fine.

In Gameplay sub-project
![Screen Shot 2013-04-15 at 12 50 54 AM](https://f.cloud.github.com/assets/673757/378277/b0f080c4-a52b-11e2-8af2-62396e0052b5.png)

In newly created project
![Screen Shot 2013-04-15 at 12 51 02 AM](https://f.cloud.github.com/assets/673757/378278/b0f4a8b6-a52b-11e2-98bc-f324b1a0c29e.png)
