### PR TITLE
Fixed iOS project to SKIP_INSTALL=YES to solve problem not able to submit to AppStore

### DIFF
--- a/gameplay/gameplay.xcodeproj/project.pbxproj
+++ b/gameplay/gameplay.xcodeproj/project.pbxproj
@@ -3903,6 +3903,7 @@
 				PUBLIC_HEADERS_FOLDER_PATH = "$(PROJECT_NAME)_include";
 				SDKROOT = iphoneos;
 				SHARED_PRECOMPS_DIR = "";
+				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				USER_HEADER_SEARCH_PATHS = "";
 				VALID_ARCHS = "armv7 armv7s i386";
@@ -3946,6 +3947,7 @@
 				PUBLIC_HEADERS_FOLDER_PATH = "$(PROJECT_NAME)_include";
 				SDKROOT = iphoneos;
 				SHARED_PRECOMPS_DIR = "";
+				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				USER_HEADER_SEARCH_PATHS = "";
 				VALID_ARCHS = "armv7 armv7s i386";


### PR DESCRIPTION
If static library project not set SKIP_INSTALL=YES, when users link
it to project, they will not able to archive project to submit to
AppStore.

This problem was described here:
http://stackoverflow.com/questions/5280914/archive-does-not-appear-in-xc
ode4-organiz
