### PR TITLE
Fix TextBox documentation

### DIFF
--- a/gameplay/src/TextBox.h
+++ b/gameplay/src/TextBox.h
@@ -19,7 +19,7 @@ namespace gameplay
  * The following properties are available for text boxes:
 
  @verbatim
-    label <labelID>
+    textBox <labelID>
     {
          style       = <styleID>
          alignment   = <Control::Alignment constant> // Note: 'position' will be ignored.


### PR DESCRIPTION
There's a little mistake in the TextBox documentation, in the sample form usage: label instead of textBox.
