### PR TITLE
Fix Linux debug build.

### DIFF
--- a/gameplay/src/PlatformLinux.cpp
+++ b/gameplay/src/PlatformLinux.cpp
@@ -923,8 +923,6 @@ namespace gameplay
 
     const GamepadInfoEntry& getGamepadMappedInfo(const GamepadHandle handle)
     {
-        GP_ASSERT(pad);
-
         for(list<ConnectedGamepadDevInfo>::iterator it = __connectedGamepads.begin(); it != __connectedGamepads.end();++it)
         {
             if(handle == (*it).fd)


### PR DESCRIPTION
Commit b623ed7 changed the way gamepads are handled. Instead of passing in a
GamePad object, it passes a handle to a GamePad object. The GP_ASSERT wasn't
update to reflect this.
