### PR TITLE
Fix Linux debug build.

### DIFF
--- a/gameplay/src/PlatformLinux.cpp
+++ b/gameplay/src/PlatformLinux.cpp
@@ -923,7 +923,7 @@ namespace gameplay
 
     const GamepadInfoEntry& getGamepadMappedInfo(const GamepadHandle handle)
     {
-        GP_ASSERT(pad);
+        GP_ASSERT(handle >= 0);
 
         for(list<ConnectedGamepadDevInfo>::iterator it = __connectedGamepads.begin(); it != __connectedGamepads.end();++it)
         {


### PR DESCRIPTION
Assert that the GamepadHandle is valid before we run through the list. "pad" was changed in February to handle and the assert was never updated.
