### PR TITLE
Update define for #1043

### DIFF
--- a/gameplay/src/Texture.cpp
+++ b/gameplay/src/Texture.cpp
@@ -162,11 +162,11 @@ Texture* Texture::create(Format format, unsigned int width, unsigned int height,
     GL_ASSERT( glGenTextures(1, &textureId) );
     GL_ASSERT( glBindTexture(GL_TEXTURE_2D, textureId) );
     GL_ASSERT( glPixelStorei(GL_UNPACK_ALIGNMENT, 1) );
-#ifndef GL_ES_VERSION_2_0
+#ifndef OPENGL_ES
     // glGenerateMipmap is new in OpenGL 3.0. For OpenGL 2.0 we must fallback to use glTexParameteri 
     // with GL_GENERATE_MIPMAP prior to actual texture creation (glTexImage2D)
-    if( generateMipmaps && glGenerateMipmap == NULL )
-        GL_ASSERT( glTexParameteri( GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_TRUE ) );
+    if ( generateMipmaps && glGenerateMipmap == NULL )
+        GL_ASSERT( glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_TRUE) );
 #endif
     GL_ASSERT( glTexImage2D(GL_TEXTURE_2D, 0, (GLenum)format, width, height, 0, (GLenum)format, GL_UNSIGNED_BYTE, data) );
 


### PR DESCRIPTION
Minor change to #1043 so it uses the OPENGL_ES define which is already used within GamePlay to distinguish between OpenGL and OpenGL ES.
