### PR TITLE
Add group bitmask filtering for PhysicsCollisionObject

### DIFF
--- a/gameplay/src/Node.cpp
+++ b/gameplay/src/Node.cpp
@@ -1105,7 +1105,7 @@ PhysicsCollisionObject* Node::getCollisionObject() const
     return _collisionObject;
 }
 
-PhysicsCollisionObject* Node::setCollisionObject(PhysicsCollisionObject::Type type, const PhysicsCollisionShape::Definition& shape, PhysicsRigidBody::Parameters* rigidBodyParameters, short group, short mask)
+PhysicsCollisionObject* Node::setCollisionObject(PhysicsCollisionObject::Type type, const PhysicsCollisionShape::Definition& shape, PhysicsRigidBody::Parameters* rigidBodyParameters, int group, int mask)
 {
     SAFE_DELETE(_collisionObject);
 

--- a/gameplay/src/Node.h
+++ b/gameplay/src/Node.h
@@ -556,7 +556,7 @@ public:
      * @param mask Bitmask to filter groups of objects to collide with this one.
      */
     PhysicsCollisionObject* setCollisionObject(PhysicsCollisionObject::Type type, const PhysicsCollisionShape::Definition& shape = PhysicsCollisionShape::box(), 
-                                               PhysicsRigidBody::Parameters* rigidBodyParameters = NULL, short group = PHYSICS_COLLISION_GROUP_DEFAULT, short mask = PHYSICS_COLLISION_MASK_DEFAULT);
+                                               PhysicsRigidBody::Parameters* rigidBodyParameters = NULL, int group = PHYSICS_COLLISION_GROUP_DEFAULT, int mask = PHYSICS_COLLISION_MASK_DEFAULT);
 
     /**
      * Sets the physics collision object for this node using the data from the Properties object defined at the specified URL, 

--- a/gameplay/src/PhysicsCharacter.cpp
+++ b/gameplay/src/PhysicsCharacter.cpp
@@ -49,7 +49,7 @@ protected:
     btScalar _minSlopeDot;
 };
 
-PhysicsCharacter::PhysicsCharacter(Node* node, const PhysicsCollisionShape::Definition& shape, float mass, short group, short mask)
+PhysicsCharacter::PhysicsCharacter(Node* node, const PhysicsCollisionShape::Definition& shape, float mass, int group, int mask)
     : PhysicsGhostObject(node, shape, group, mask), _moveVelocity(0,0,0), _forwardVelocity(0.0f), _rightVelocity(0.0f),
     _verticalVelocity(0, 0, 0), _currentVelocity(0,0,0), _normalizedVelocity(0,0,0),
     _colliding(false), _collisionNormal(0,0,0), _currentPosition(0,0,0), _stepHeight(0.1f),

--- a/gameplay/src/PhysicsCharacter.h
+++ b/gameplay/src/PhysicsCharacter.h
@@ -196,8 +196,10 @@ private:
      * @param node Scene node that represents the character.
      * @param shape Physics collision shape definition.
      * @param mass The mass of the character.
+     * @param group Group identifier
+     * @param mask Bitmask field for filtering collisions with this object.
      */
-    PhysicsCharacter(Node* node, const PhysicsCollisionShape::Definition& shape, float mass, short group = PHYSICS_COLLISION_GROUP_DEFAULT, short mask = PHYSICS_COLLISION_MASK_DEFAULT);
+    PhysicsCharacter(Node* node, const PhysicsCollisionShape::Definition& shape, float mass, int group = PHYSICS_COLLISION_GROUP_DEFAULT, int mask = PHYSICS_COLLISION_MASK_DEFAULT);
 
     /**
      * Destructor.

--- a/gameplay/src/PhysicsCollisionObject.cpp
+++ b/gameplay/src/PhysicsCollisionObject.cpp
@@ -34,7 +34,7 @@ struct CollidesWithCallback : public btCollisionWorld::ContactResultCallback
     bool result;
 };
 
-PhysicsCollisionObject::PhysicsCollisionObject(Node* node, short group, short mask)
+PhysicsCollisionObject::PhysicsCollisionObject(Node* node, int group, int mask)
     : _node(node), _collisionShape(NULL), _enabled(true), _scriptListeners(NULL), _motionState(NULL), _group(group), _mask(mask)
 {
 }

--- a/gameplay/src/PhysicsCollisionObject.h
+++ b/gameplay/src/PhysicsCollisionObject.h
@@ -330,7 +330,7 @@ protected:
     /**
      * Constructor.
      */
-    PhysicsCollisionObject(Node* node, short group = PHYSICS_COLLISION_GROUP_DEFAULT, short mask = PHYSICS_COLLISION_MASK_DEFAULT);
+    PhysicsCollisionObject(Node* node, int group = PHYSICS_COLLISION_GROUP_DEFAULT, int mask = PHYSICS_COLLISION_MASK_DEFAULT);
 
     /**
      * Returns the Bullet Physics collision object.
@@ -422,8 +422,8 @@ private:
     /**
      * Group identifier and the bitmask for collision filtering.
      */
-    short _group;
-    short _mask;
+    int _group;
+    int _mask;
 };
 
 }

--- a/gameplay/src/PhysicsController.cpp
+++ b/gameplay/src/PhysicsController.cpp
@@ -629,8 +629,8 @@ void PhysicsController::addCollisionObject(PhysicsCollisionObject* object)
     // Assign user pointer for the bullet collision object to allow efficient
     // lookups of bullet objects -> gameplay objects.
     object->getCollisionObject()->setUserPointer(object);
-    short group = object->_group;
-    short mask = object->_mask;
+    short group = (short)object->_group;
+    short mask = (short)object->_mask;
 
     // Add the object to the physics world.
     switch (object->getType())

--- a/gameplay/src/PhysicsGhostObject.cpp
+++ b/gameplay/src/PhysicsGhostObject.cpp
@@ -6,7 +6,7 @@
 namespace gameplay
 {
 
-PhysicsGhostObject::PhysicsGhostObject(Node* node, const PhysicsCollisionShape::Definition& shape, short group, short mask)
+PhysicsGhostObject::PhysicsGhostObject(Node* node, const PhysicsCollisionShape::Definition& shape, int group, int mask)
     : PhysicsCollisionObject(node, group, mask), _ghostObject(NULL)
 {
     Vector3 centerOfMassOffset;

--- a/gameplay/src/PhysicsGhostObject.h
+++ b/gameplay/src/PhysicsGhostObject.h
@@ -45,7 +45,7 @@ protected:
      * @param group Group identifier
      * @param mask Bitmask field for filtering collisions with this object.
      */
-    PhysicsGhostObject(Node* node, const PhysicsCollisionShape::Definition& shape, short group = PHYSICS_COLLISION_GROUP_DEFAULT, short mask = PHYSICS_COLLISION_MASK_DEFAULT);
+    PhysicsGhostObject(Node* node, const PhysicsCollisionShape::Definition& shape, int group = PHYSICS_COLLISION_GROUP_DEFAULT, int mask = PHYSICS_COLLISION_MASK_DEFAULT);
 
     /**
      * Destructor.

--- a/gameplay/src/PhysicsRigidBody.cpp
+++ b/gameplay/src/PhysicsRigidBody.cpp
@@ -10,7 +10,7 @@
 namespace gameplay
 {
 
-PhysicsRigidBody::PhysicsRigidBody(Node* node, const PhysicsCollisionShape::Definition& shape, const Parameters& parameters, short group, short mask)
+PhysicsRigidBody::PhysicsRigidBody(Node* node, const PhysicsCollisionShape::Definition& shape, const Parameters& parameters, int group, int mask)
         : PhysicsCollisionObject(node, group, mask), _body(NULL), _mass(parameters.mass), _constraints(NULL), _inDestructor(false)
 {
     GP_ASSERT(Game::getInstance()->getPhysicsController());

--- a/gameplay/src/PhysicsRigidBody.h
+++ b/gameplay/src/PhysicsRigidBody.h
@@ -399,7 +399,7 @@ private:
      * @param group Group identifier
      * @param mask Bitmask field for filtering collisions with this object.
      */
-    PhysicsRigidBody(Node* node, const PhysicsCollisionShape::Definition& shape, const Parameters& parameters, short group = PHYSICS_COLLISION_GROUP_DEFAULT, short mask = PHYSICS_COLLISION_MASK_DEFAULT);
+    PhysicsRigidBody(Node* node, const PhysicsCollisionShape::Definition& shape, const Parameters& parameters, int group = PHYSICS_COLLISION_GROUP_DEFAULT, int mask = PHYSICS_COLLISION_MASK_DEFAULT);
 
     /**
      * Destructor.


### PR DESCRIPTION
PhysicsCharacter, PhysicsGhostObject and PhysicsRigidBody now supports
collision filtering using bitmasks.

See issue #1029 on github.
