### PR TITLE
Fixed compilation error on Android

### DIFF
--- a/gameplay/src/TextBox.cpp
+++ b/gameplay/src/TextBox.cpp
@@ -490,7 +490,7 @@ std::string TextBox::getDisplayedText() const
     std::string displayedText;
     switch (_inputMode) {
         case PASSWORD:
-            displayedText.insert(0, _text.length(), _passwordChar);
+            displayedText.insert((size_t)0, _text.length(), _passwordChar);
             break;
 
         case TEXT:


### PR DESCRIPTION
Without the explicit cast call to std::string::insert(size_t, size_t, char)
becomes ambiguous.
