### PR TITLE
Android build: Clean assets folder before building package

### DIFF
--- a/template/android/template.build.xml
+++ b/template/android/template.build.xml
@@ -62,6 +62,7 @@
        If this is not done in place, override ${out.dex.input.absolute.dir} */
        -->
     <target name="-post-compile">
+    	<delete dir="assets/res"/>
         <copy todir="assets/res">
             <fileset dir="../res" />
         </copy>


### PR DESCRIPTION
Otherwise deleted files from the project remain in the built .apk archive.
