### PR TITLE
Simply reverted part of sgrenier fix regarding loopBlendTime

### DIFF
--- a/gameplay/src/Animation.cpp
+++ b/gameplay/src/Animation.cpp
@@ -254,7 +254,7 @@ void Animation::createClips(Properties* animationProperties, unsigned int frameC
         int begin = pClip->getInt("begin");
         int end = pClip->getInt("end");
 
-        AnimationClip* clip = createClip(pClip->getId(), ((float)begin / (frameCount-1)) * _duration, ((float)end / (frameCount-1)) * _duration);
+        AnimationClip* clip = createClip(pClip->getId(), ((float)begin / frameCount) * _duration, ((float)end / frameCount) * _duration);
 
         const char* repeat = pClip->getString("repeatCount");
         if (repeat)


### PR DESCRIPTION
Prevents division by zero when there is only one frame
