### PR TITLE
Fixed permanent dirty state on containers containing hidden controls

### DIFF
--- a/gameplay/src/Container.cpp
+++ b/gameplay/src/Container.cpp
@@ -502,7 +502,10 @@ void Container::draw(SpriteBatch* spriteBatch, const Rectangle& clip, bool needs
     }
 
     if (!_visible)
+    {
+        _dirty = false;
         return;
+    }
 
     spriteBatch->start();
     Control::drawBorder(spriteBatch, clip);

--- a/gameplay/src/Control.cpp
+++ b/gameplay/src/Control.cpp
@@ -1132,7 +1132,10 @@ void Control::draw(SpriteBatch* spriteBatch, const Rectangle& clip, bool needsCl
     }
 
     if (!_visible)
+    {
+        _dirty = false;
         return;
+    }
 
     spriteBatch->start();
     drawBorder(spriteBatch, clip);

--- a/gameplay/src/Slider.cpp
+++ b/gameplay/src/Slider.cpp
@@ -494,7 +494,10 @@ void Slider::draw(SpriteBatch* spriteBatch, const Rectangle& clip, bool needsCle
     }
 
     if (!_visible)
+    {
+        _dirty = false;
         return;
+    }
 
     spriteBatch->start();
     drawBorder(spriteBatch, clip);


### PR DESCRIPTION
If you call setVisible(false) on any Form control, then the Form's dirty state will always be true, causing form being rendered to FrameBuffer every frame.
