### PR TITLE
GPB file header symbols fix in source files according to the gameplay-bu...

### DIFF
--- a/tools/encoder/src/TTFFontEncoder.cpp
+++ b/tools/encoder/src/TTFFontEncoder.cpp
@@ -255,7 +255,7 @@ int writeFont(const char* inFilePath, const char* outFilePath, unsigned int font
     FILE *gpbFp = fopen(outFilePath, "wb");
     
     // File header and version.
-    char fileHeader[9]     = {'«', 'G', 'P', 'B', '»', '\r', '\n', '\x1A', '\n'};
+    char fileHeader[9]     = {'\xAB', 'G', 'P', 'B', '\xBB', '\r', '\n', '\x1A', '\n'};
     fwrite(fileHeader, sizeof(char), 9, gpbFp);
     fwrite(gameplay::GPB_VERSION, sizeof(char), 2, gpbFp);
 


### PR DESCRIPTION
GPB file header symbols fix in source files according to the gameplay-bundle definition. Using '«' and '»' instead of '\xAB' and '\xBB' causes IDE editor warnings and compiler warnings on linux systems (github also shows them wrong).
