### PR TITLE
Fixed issue in PlatformWindows.cpp with __hrc causing a crash if null.

### DIFF
--- a/gameplay/src/PlatformWindows.cpp
+++ b/gameplay/src/PlatformWindows.cpp
@@ -740,7 +740,7 @@ bool initializeGL(WindowCreationParams* params)
     wglDeleteContext(tempContext);
 
     // Make the new context current
-    if (!wglMakeCurrent(__hdc, __hrc) || !__hrc)
+    if (!__hrc || !wglMakeCurrent(__hdc, __hrc) )
     {
         GP_ERROR("Failed to make the window current.");
         return false;


### PR DESCRIPTION
When making the new context current, condition order caused a crash if __hrc was null.  Switching the condition order causes an exit if it's null.

Suggested by JVene in the Issues section.
