### PR TITLE
resolved compiler error with ios-8859-1 character '\xAB' '\xBB' in other...... language system

### DIFF
--- a/tools/encoder/src/TTFFontEncoder.cpp
+++ b/tools/encoder/src/TTFFontEncoder.cpp
@@ -311,7 +311,7 @@ int writeFont(const char* inFilePath, const char* outFilePath, unsigned int font
     
     // File header and version.
     FILE *gpbFp = fopen(outFilePath, "wb");
-    char fileHeader[9]     = {'«', 'G', 'P', 'B', '»', '\r', '\n', '\x1A', '\n'};
+    char fileHeader[9]     = {'\xAB', 'G', 'P', 'B', '\xBB', '\r', '\n', '\x1A', '\n'};
     fwrite(fileHeader, sizeof(char), 9, gpbFp);
     fwrite(gameplay::GPB_VERSION, sizeof(char), 2, gpbFp);
 


### PR DESCRIPTION
resolved compiler error with ios-8859-1 character '\xAB' '\xBB' in other...... language system. 
Issue #1194
