### PR TITLE
fixed compile error with vs2012

### DIFF
--- a/gameplay/src/ParticleEmitter.cpp
+++ b/gameplay/src/ParticleEmitter.cpp
@@ -889,7 +889,7 @@ void ParticleEmitter::update(float elapsedTime)
         {
             if ((int)_timePerEmission > 0)
             {
-                _emitTime = fmod(_emitTime, (double)_timePerEmission);
+                _emitTime = fmod((double)_emitTime, (double)_timePerEmission);
             }
             emitOnce(emitCount);
         }


### PR DESCRIPTION
fmod function in vs2012 has 3 different definitions,
current code has different type arguments. cause compile error in vs2012.
