### PR TITLE
Fixed the FBX material generation more.

### DIFF
--- a/tools/encoder/src/Material.cpp
+++ b/tools/encoder/src/Material.cpp
@@ -146,11 +146,6 @@ bool Material::isTextured() const
     return !_samplers.empty();
 }
 
-bool Material::isBumped() const
-{
-    return getSampler("u_normalmapTexture") != NULL;
-}
-
 bool Material::isLit() const
 {
     return _lit;

--- a/tools/encoder/src/Material.h
+++ b/tools/encoder/src/Material.h
@@ -56,7 +56,6 @@ public:
     Sampler* getSampler(const std::string& id) const;
     
     bool isTextured() const;
-    bool isBumped() const;
     bool isLit() const;
     bool isSpecular() const;
     bool isTextureRepeat() const;


### PR DESCRIPTION
Material should not defined light definitions by default since we don't know what the user wants anyhow.
Removed eBumpNormaMap generated materials since this is not working from FBX SDK.
