### PR TITLE
Modified Bundle::create to add new Bundle to cache

### DIFF
--- a/gameplay/src/Bundle.cpp
+++ b/gameplay/src/Bundle.cpp
@@ -233,6 +233,9 @@ Bundle* Bundle::create(const char* path)
     bundle->_references = refs;
     bundle->_stream = stream;
 
+	// Add bundle to the cache.
+    __bundleCache.push_back(bundle);
+
     return bundle;
 }
 


### PR DESCRIPTION
Modified "Bundle::create" method to add new Bundles to the cache, as currently nothing is ever pushed back into the __bundleCache vector.

Note, however, that when creating physics objects from a .scene file, Bundles are repeatedly created and destroyed so, in order to benefit from the Bundle cache, it is currently necessary to keep a separate reference to the Bundle alive in the Game's initialize() method, e.g:

<pre><code>
void RacerGame::initialize()
{
...
// Create persistent reference to Bundle file which will be stored in cache
_bundlePointer = Bundle::create("res/common/game.gpb");
// Load the scene
_scene = Scene::load("res/common/game.scene"); // will likely create and destroy multiple bundles referring to game.gpb
...
// Release Bundle once all assets have been loaded from it
SAFE_RELEASE(_bundlePointer);
...
}
</code></pre>
