### PR TITLE
Fixes order of extensions in fragment shader for Samsung Galaxy Note

### DIFF
--- a/gameplay/res/shaders/font.frag
+++ b/gameplay/res/shaders/font.frag
@@ -1,6 +1,6 @@
 #ifdef OPENGL_ES
-precision highp float;
 #extension GL_OES_standard_derivatives : enable
+precision highp float;
 #endif
 
 ///////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixed #1266
