### PR TITLE
Fixes for Android

### DIFF
--- a/newproject.sh
+++ b/newproject.sh
@@ -235,6 +235,7 @@ aliassedinplace "s*TEMPLATE_UUID*$uuid*g" "$projPath/android/AndroidManifest.xml
 
 cp "template/android/template.build.xml" "$projPath/android/build.xml"
 aliassedinplace "s*TEMPLATE_PROJECT*$projName*g" "$projPath/android/build.xml"
+aliassedinplace "s*GAMEPLAY_PATH*$gpPath*g" "$projPath/android/build.xml"
 
 cp "template/android/jni/Application.mk" "$projPath/android/jni/Application.mk"
 cp "template/android/jni/template.Android.mk" "$projPath/android/jni/Android.mk"

--- a/template/android/template.build.xml
+++ b/template/android/template.build.xml
@@ -50,7 +50,14 @@
      in between standard targets -->
 
     <target name="-pre-build">
-		<mkdir dir="src"/>
+        <mkdir dir="src"/>
+        <exec executable="ndk-build" failonerror="true" />
+    </target>
+
+    <target name="clean">
+        <exec executable="ndk-build" failonerror="true">
+            <arg value="clean" />
+        </exec>
     </target>
 	
 <!--
@@ -62,9 +69,12 @@
        If this is not done in place, override ${out.dex.input.absolute.dir} */
        -->
     <target name="-post-compile">
-    	<delete dir="assets/res"/>
+        <delete dir="assets/res" />
         <copy todir="assets/res">
             <fileset dir="../res" />
+        </copy>
+        <copy todir="assets/res/shaders">
+            <fileset dir="../GAMEPLAY_PATH/gameplay/res/shaders" />
         </copy>
     </target>
 


### PR DESCRIPTION
- Copies shaders in `-post-compile` step to `assets/res` on Android
- Automatically runs `ndk-build` when building via `ant`
