### PR TITLE
Fix encoder spot light angle conversion

### DIFF
--- a/tools/encoder/src/FBXSceneEncoder.cpp
+++ b/tools/encoder/src/FBXSceneEncoder.cpp
@@ -830,7 +830,8 @@ void FBXSceneEncoder::loadLight(FbxNode* fbxNode, Node* node)
             break;
         }
 
-        light->setFalloffAngle(MATH_DEG_TO_RAD((float)fbxLight->OuterAngle.Get())); // fall off angle
+        light->setInnerAngle(MATH_DEG_TO_RAD((float)fbxLight->InnerAngle.Get()));
+        light->setOuterAngle(MATH_DEG_TO_RAD((float)fbxLight->OuterAngle.Get()));
         break;
     }
     default:

--- a/tools/encoder/src/Light.cpp
+++ b/tools/encoder/src/Light.cpp
@@ -9,7 +9,6 @@ Light::Light(void) :
     _constantAttenuation(0.0f),
     _linearAttenuation(0.0f),
     _quadraticAttenuation(0.0f),
-    _falloffAngle(0.0f),
     _falloffExponent(0.0f),
     _range(-1.0f),
     _innerAngle(-1.0f),
@@ -55,44 +54,6 @@ float Light::computeRange(float constantAttenuation, float linearAttenuation, fl
     return range;
 }
 
-float lerpstep( float lower, float upper, float s)
-{
-    float lerpstep = ( s - lower ) / ( upper - lower );
-    
-    if (lerpstep < 0.0f)
-        lerpstep = 0.0f;
-    else if (lerpstep > 1.0f)
-        lerpstep = 1.0f;
-    
-    return lerpstep;
-}
-
-float Light::computeInnerAngle(float outerAngle)
-{
-    const float epsilon = 0.15f;
-
-    // Set inner angle to half of outer angle.
-    float innerAngle = outerAngle / 2.0f;
-
-    // Try to find the inner angle by sampling the attenuation with steps of angle.
-    for (float angle = 0.0; angle < outerAngle; angle += epsilon)
-    {
-        float outerCosAngle = cos(MATH_DEG_TO_RAD(outerAngle));
-        float innerCosAngle = cos(MATH_DEG_TO_RAD(innerAngle));
-            
-        float cosAngle = cos(MATH_DEG_TO_RAD(angle));
-        float att = lerpstep(outerCosAngle, innerCosAngle, cosAngle);
-        
-        if (att < 1.0f)
-        {
-            innerAngle = angle;
-            break;
-        }
-    }
-
-    return innerAngle;
-}
-
 void Light::writeBinary(FILE* file)
 {
     Object::writeBinary(file);
@@ -108,14 +69,6 @@ void Light::writeBinary(FILE* file)
 
     if (_lightType == SpotLight)
     {
-        // Compute an approximate inner angle of the spot light using Collada's outer angle.
-        _outerAngle = _falloffAngle / 2.0f;
-        
-        if (_innerAngle == -1.0f)
-        {
-            _innerAngle = computeInnerAngle(_outerAngle);
-        }
-
         write(_range, file);
         write(_innerAngle, file);
         write(_outerAngle, file);
@@ -141,13 +94,6 @@ void Light::writeText(FILE* file)
 
     if (_lightType == SpotLight)
     {
-        // Compute an approximate inner angle of the spot light using Collada's outer angle.
-        _outerAngle = _falloffAngle / 2.0f;
-        if (_innerAngle == -1.0f)
-        {
-            _innerAngle = computeInnerAngle(_outerAngle);
-        }
-
         fprintfElement(file, "range", _range);
         fprintfElement(file, "innerAngle", MATH_DEG_TO_RAD(_innerAngle));
         fprintfElement(file, "outerAngle", MATH_DEG_TO_RAD(_outerAngle));
@@ -214,9 +160,13 @@ void Light::setQuadraticAttenuation(float value)
 {
     _quadraticAttenuation = value;
 }
-void Light::setFalloffAngle(float value)
+void Light::setInnerAngle(float value)
 {
-    _falloffAngle = value;
+    _innerAngle = value;
+}
+void Light::setOuterAngle(float value)
+{
+    _outerAngle = value;
 }
 void Light::setFalloffExponent(float value)
 {

--- a/tools/encoder/src/Light.h
+++ b/tools/encoder/src/Light.h
@@ -47,7 +47,8 @@ public:
     void setConstantAttenuation(float value);
     void setLinearAttenuation(float value);
     void setQuadraticAttenuation(float value);
-    void setFalloffAngle(float value);
+    void setInnerAngle(float value);
+    void setOuterAngle(float value);
     void setFalloffExponent(float value);
 
     enum LightType
@@ -69,7 +70,6 @@ private:
     float _constantAttenuation;
     float _linearAttenuation;
     float _quadraticAttenuation;
-    float _falloffAngle;
     float _falloffExponent;
 
     float _range;


### PR DESCRIPTION
Light inner/outer angles are [already in radians](https://github.com/blackberry/GamePlay/blob/4067ce019dccb23a38a6b186b77f43c6fe986e5c/tools/encoder/src/FBXSceneEncoder.cpp#L822), no need to convert again when writing out.  This fixes light nodes having bogus inner and outer angles when loading from a `.gpb` that was generated from a `.fbx`.

This is only a step in the right direction though; when exporting a light from, say, blender, the inner and outer angles are written into the file, however `gameplay-encoder` only reads in the outer angle (called `falloffAngle`) and then computes an estimated inner angle.  Should I submit a PR to read in the true inner and outer angles from the `.fbx`?

An example `.fbx` with the inner and outer angles present is [here](https://gist.github.com/staticfloat/7798794).  I am specifically referring to the `spot` node.
