### PR TITLE
Remove include of deleted file (SocialController)

### DIFF
--- a/gameplay/src/PlatformBlackBerry.cpp
+++ b/gameplay/src/PlatformBlackBerry.cpp
@@ -3,7 +3,6 @@
 #include "Base.h"
 #include "Platform.h"
 #include "FileSystem.h"
-#include "SocialController.h"
 #include "Game.h"
 #include "Form.h"
 #include "ScriptController.h"


### PR DESCRIPTION
`SocialControler.h` is still included in `PlatformBlackBerry.h` but doesn't exist anymore.
