### PR TITLE
Fixes needed for FBX 2014.2

### DIFF
--- a/tools/encoder/CMakeLists.txt
+++ b/tools/encoder/CMakeLists.txt
@@ -16,11 +16,12 @@ link_directories(
     ${CMAKE_SOURCE_DIR}/external-deps/freetype2/lib/linux/${ARCH_DIR}
     /usr/lib/gcc4/${ARCH_DIR}
     /usr/lib
+    /usr/lib/gcc4/x64/release/
 )
 
 set(APP_LIBRARIES
     dl
-    fbxsdk-2013.3-static
+    fbxsdk
     png
     z   
     freetype

--- a/tools/encoder/src/EncoderArguments.cpp
+++ b/tools/encoder/src/EncoderArguments.cpp
@@ -7,6 +7,9 @@
     #define PATH_MAX    _MAX_PATH
     #define realpath(A,B)    _fullpath(B,A,PATH_MAX)
 #endif
+#ifdef __linux__
+    #include <linux/limits.h>
+#endif
 
 #define MAX_HEIGHTMAP_SIZE 2049
 

--- a/tools/encoder/src/FBXSceneEncoder.cpp
+++ b/tools/encoder/src/FBXSceneEncoder.cpp
@@ -34,7 +34,7 @@ void FBXSceneEncoder::write(const string& filepath, const EncoderArguments& argu
     if (!importer->Initialize(filepath.c_str(), -1, sdkManager->GetIOSettings()))
     {
         LOG(1, "Call to FbxImporter::Initialize() failed.\n");
-        LOG(1, "Error returned: %s\n\n", importer->GetLastErrorString());
+        LOG(1, "Error returned: %s\n\n", importer->GetStatus().GetErrorString());
         exit(-1);
     }
     

--- a/tools/encoder/src/GPBFile.cpp
+++ b/tools/encoder/src/GPBFile.cpp
@@ -4,6 +4,7 @@
 #include "StringUtil.h"
 #include "EncoderArguments.h"
 #include "Heightmap.h"
+#include <climits>
 
 #define EPSILON 1.2e-7f;
 


### PR DESCRIPTION
Platform: Linux/ xubuntu 12.04
Build-type: cmake
Build-type: debug
1. The FBX sdk seems to have upgraded from 2013.3 -> 2014.2 with api breaking changes. I wasn't able to find the 2013.3 sdk (your docs don't specify a version until I saw it in the encoder's cmake file) I wasn't able to use the pre-built executable in `bin/linux` due to 

``` bash
      ./gameplay-encoder: symbol lookup error: ./gameplay-encoder: undefined symbol: 
      _ZN13fbxsdk_2014_117FbxSurfaceLambert7ClassIdE
```
1. During rebuilding, I recieved 5 errors, 1) missing `PATH_MAX`, 2) missing `INT_MAX`, 3) the `GetLastErrorString` api change 4) unable to link `libfbxsdk-2013.3-static` 5) unable to find `ft2header.h`. I fixed 5 by just building in the super directory instead of in the encoder directory (your docs kinda specify that but it's unclear).

The changes listed here allow me to build and run the encoder.

The `FBXSceneEncoder.cpp` changes are probably the only changes needed for the new version and the rest are either linux-specific, or simply my-machine-specific.
