### PR TITLE
Material auto binding changes

### DIFF
--- a/gameplay/src/MaterialParameter.cpp
+++ b/gameplay/src/MaterialParameter.cpp
@@ -497,11 +497,11 @@ void MaterialParameter::bind(Effect* effect)
         effect->setValue(_uniform, _value.samplerArrayValue, _count);
         break;
     case MaterialParameter::METHOD:
-        GP_ASSERT(_value.method);
-        _value.method->setValue(effect);
+        if (_value.method)
+            _value.method->setValue(effect);
         break;
     default:
-        GP_ERROR("Unsupported material parameter type (%d).", _type);
+        GP_WARN("Unknown type (%d) for material parameter: %s", _type, _name.c_str());
         break;
     }
 }

--- a/gameplay/src/RenderState.h
+++ b/gameplay/src/RenderState.h
@@ -27,6 +27,74 @@ class RenderState : public Ref
 public:
 
     /**
+    * An abstract base class that can be extended to support custom material auto bindings.
+    *
+    * Implementing a custom auto binding resolver allows the set of built-in parameter auto
+    * bindings to be extended or overridden. Any parameter auto binding that is set on a
+    * material will be forwarded to any custom auto binding resolvers, in the order in which
+    * they are registered. If a registered resolver returns true (specifying that it handles
+    * the specified autoBinding), no further code will be executed for that autoBinding.
+    * This allows auto binding resolvers to not only implement new/custom binding strings,
+    * but it also lets them override existing/built-in ones. For this reason, you should
+    * ensure that you ONLY return true if you explicitly handle a custom auto binding; return
+    * false otherwise.
+    *
+    * Note that the custom resolver is called only once for a RenderState object when its
+    * node binding is initially set. This occurs when a material is initially bound to a
+    * renderable (Model, Terrain, etc) that belongs to a Node. The resolver is NOT called
+    * each frame or each time the RenderState is bound. Therefore, when implementing custom
+    * auto bindings for values that change over time, you should bind a method pointer to
+    * the passed in MaterialParaemter using the MaterialParameter::bindValue method. This way,
+    * the bound method will be called each frame to set an updated value into the MaterialParameter.
+    *
+    * If no registered resolvers explicitly handle an auto binding, the binding will attempt
+    * to be resolved using the internal/built-in resolver, which is able to handle any
+    * auto bindings found in the RenderState::AutoBinding enumeration.
+    *
+    * When an instance of a class that extends AutoBindingResolver is created, it is automatically
+    * registered as a custom auto binding handler. Likewise, it is automatically deregistered
+    * on destruction.
+    *
+    * @script{ignore}
+    */
+    class AutoBindingResolver
+    {
+    public:
+
+        /**
+         * Destructor.
+         */
+        virtual ~AutoBindingResolver();
+
+        /**
+        * Called when an unrecognized material auto binding is encountered
+        * during material loading.
+        *
+        * Implemenations of this method should do a string comparison on the passed
+        * in name parameter and decide whether or not they should handle the
+        * parameter. If the parameter is not handled, false should be returned so
+        * that other auto binding resolvers get a chance to handle the parameter.
+        * Otherwise, the parameter should be set or bound and true should be returned.
+        *
+        * @param autoBinding Name of the auto binding to be resolved.
+        * @param node The node that the material is attached to.
+        * @param parameter The material parameter to be bound (if true is returned).
+        *
+        * @return True if the auto binding is handled and the associated parmeter is
+        *      bound, false otherwise.
+        */
+        virtual bool resolveAutoBinding(const char* autoBinding, Node* node, MaterialParameter* parameter) = 0;
+
+    protected:
+
+        /**
+         * Constructor.
+         */
+        AutoBindingResolver();
+
+    };
+
+    /**
      * Built-in auto-bind targets for material parameters.
      */
     enum AutoBinding
@@ -93,26 +161,6 @@ public:
          */
         SCENE_AMBIENT_COLOR
     };
-
-    /**
-     * Callback function prototype for resolving material parameter auto bindings.
-     *
-     * Functions matching this callback signature can be registered via the 
-     * RenderState::registerAutoBindingResolver method to extend or override the set
-     * of built-in material parameter auto bindings.
-     *
-     * @param autoBinding Name of the auto binding to resolve.
-     * @param node Node that is bound to the material of the specified parameter.
-     * @param parameter Material parameter to set the binding on.
-     *
-     * @return True ONLY if the implementations explicitly handles the auto binding, false otherwise.
-     *      Returning true here will prevent any further code (including built-in resolving code) from
-     *      handling the auto binding.
-     *
-     * @see RenderState::registerAutoBindingResolver(const char*, RenderState::AutoBindingResolver)
-     * @script{ignore}
-     */
-    typedef bool (*ResolveAutoBindingCallback) (const char* autoBinding, Node* node, MaterialParameter* parameter);
 
     /**
      * Defines blend constants supported by the blend function.
@@ -523,36 +571,6 @@ public:
      */
     virtual void setNodeBinding(Node* node);
 
-    /**
-     * Registers a custom auto binding resolver.
-     *
-     * Implementing a custom auto binding resolver allows the set of built-in parameter auto
-     * bindings to be extended or overridden. Any parameter auto binding that is set on a
-     * material will be forwarded to any custom auto binding resolvers, in the order in which
-     * they are registered. If a registered resolver returns true (specifying that it handles
-     * the specified autoBinding), no further code will be executed for that autoBinding.
-     * This allows auto binding resolvers to not only implement new/custom binding strings,
-     * but it also lets them override existing/built-in ones. For this reason, you should
-     * ensure that you ONLY return true if you explicitly handle a custom auto binding; return
-     * false otherwise.
-     *
-     * Note that the custom resolver is called only once for a RenderState object when its
-     * node binding is initially set. This occurs when a material is initially bound to a
-     * Model that belongs to a Node. The resolver is NOT called each frame or each time
-     * the RenderState is bound. Therefore, when implementing custom auto bindings for values
-     * that change over time, the you should bind a method pointer onto the passed in
-     * MaterialParaemter using the MaterialParameter::bindValue method. This way, the bound
-     * method will be called each frame to set an updated value into the MaterialParameter.
-     *
-     * If no registered resolvers explicitly handle an auto binding, the binding will attempt
-     * to be resolved using the internal/built-in resolver, which is able to handle any
-     * auto bindings found in the RenderState::AutoBinding enumeration.
-     *
-     * @param callback Callback function for resolving parameter auto bindings.
-     * @script{ignore}
-     */
-    static void registerAutoBindingResolver(ResolveAutoBindingCallback callback);
-
 protected:
 
     /**
@@ -661,7 +679,7 @@ protected:
     /**
      * Map of custom auto binding resolvers.
      */
-    static std::vector<ResolveAutoBindingCallback> _customAutoBindingResolvers;
+    static std::vector<AutoBindingResolver*> _customAutoBindingResolvers;
 };
 
 }

--- a/gameplay/src/Terrain.h
+++ b/gameplay/src/Terrain.h
@@ -13,6 +13,7 @@ namespace gameplay
 
 class Node;
 class TerrainPatch;
+class TerrainAutoBindingResolver;
 
 /**
  * Defines a Terrain that is capable of rendering large landscapes from 2D heightmap images.
@@ -82,9 +83,10 @@ class TerrainPatch;
 class Terrain : public Ref, public Transform::Listener
 {
     friend class Node;
-    friend class TerrainPatch;
     friend class PhysicsController;
     friend class PhysicsRigidBody;
+    friend class TerrainPatch;
+    friend class TerrainAutoBindingResolver;
 
 public:
 

--- a/gameplay/src/TerrainPatch.cpp
+++ b/gameplay/src/TerrainPatch.cpp
@@ -23,17 +23,20 @@ template <class T> T clamp(T value, T min, T max) { return value < min ? min : (
 #define TERRAINPATCH_DIRTY_LEVEL 4
 #define TERRAINPATCH_DIRTY_ALL (TERRAINPATCH_DIRTY_MATERIAL | TERRAINPATCH_DIRTY_BOUNDS | TERRAINPATCH_DIRTY_LEVEL)
 
-static bool __autoBindingResolverRegistered = false;
+/**
+ * Custom material auto-binding resolver for terrain.
+ * @script{ignore}
+ */
+class TerrainAutoBindingResolver : RenderState::AutoBindingResolver
+{
+    bool resolveAutoBinding(const char* autoBinding, Node* node, MaterialParameter* parameter);
+};
+static TerrainAutoBindingResolver __autoBindingResolver;
 static int __currentPatchIndex = -1;
 
 TerrainPatch::TerrainPatch() :
-_terrain(NULL), _row(0), _column(0), _camera(NULL), _level(0), _bits(TERRAINPATCH_DIRTY_ALL)
+    _terrain(NULL), _row(0), _column(0), _camera(NULL), _level(0), _bits(TERRAINPATCH_DIRTY_ALL)
 {
-    if (!__autoBindingResolverRegistered)
-    {
-        RenderState::registerAutoBindingResolver(TerrainPatch::autoBindingResolver);
-        __autoBindingResolverRegistered = true;
-    }
 }
 
 TerrainPatch::~TerrainPatch()
@@ -708,7 +711,7 @@ void TerrainPatch::updateNodeBinding(Node* node)
     __currentPatchIndex = -1;
 }
 
-bool TerrainPatch::autoBindingResolver(const char* autoBinding, Node* node, MaterialParameter* parameter)
+bool TerrainAutoBindingResolver::resolveAutoBinding(const char* autoBinding, Node* node, MaterialParameter* parameter)
 {
     if (strcmp(autoBinding, "TERRAIN_WORLD_MATRIX") == 0)
     {

--- a/gameplay/src/TerrainPatch.h
+++ b/gameplay/src/TerrainPatch.h
@@ -8,6 +8,7 @@ namespace gameplay
 {
 
 class Terrain;
+class TerrainAutoBindingResolver;
 
 /**
  * Defines a single patch for a Terrain.
@@ -15,6 +16,7 @@ class Terrain;
 class TerrainPatch : public Camera::Listener
 {
     friend class Terrain;
+    friend class TerrainAutoBindingResolver;
 
 public:
 
@@ -133,8 +135,6 @@ private:
     void updateNodeBinding(Node* node);
 
     std::string passCreated(Pass* pass);
-
-    static bool autoBindingResolver(const char* autoBinding, Node* node, MaterialParameter* parameter);
 
     Terrain* _terrain;
     unsigned int _index;

--- a/samples/browser/res/common/terrain/shapes.material
+++ b/samples/browser/res/common/terrain/shapes.material
@@ -2,7 +2,10 @@ material textured
 {
     u_worldViewProjectionMatrix = WORLD_VIEW_PROJECTION_MATRIX
     u_inverseTransposeWorldViewMatrix = INVERSE_TRANSPOSE_WORLD_VIEW_MATRIX
+    
     u_ambientColor = SCENE_AMBIENT_COLOR
+    u_directionalLightDirection[0] = LIGHT0_DIRECTION_VIEW
+    u_directionalLightColor[0] = LIGHT0_COLOR
 
     sampler u_diffuseTexture
     {

--- a/samples/browser/res/common/terrain/terrain.material
+++ b/samples/browser/res/common/terrain/terrain.material
@@ -9,8 +9,8 @@ material terrain
     u_surfaceLayerMaps = TERRAIN_LAYER_MAPS
 
     u_ambientColor = SCENE_AMBIENT_COLOR
-    u_directionalLightDirection[0] = DIRECTIONAL_LIGHT_DIRECTION
-    u_directionalLightColor[0] = DIRECTIONAL_LIGHT_COLOR
+    u_directionalLightDirection[0] = LIGHT0_DIRECTION_WORLD
+    u_directionalLightColor[0] = LIGHT0_COLOR
 
     renderState
     {

--- a/samples/browser/src/TerrainSample.h
+++ b/samples/browser/src/TerrainSample.h
@@ -6,7 +6,7 @@
 
 using namespace gameplay;
 
-class TerrainSample : public Sample, public Control::Listener
+class TerrainSample : public Sample, public Control::Listener, private RenderState::AutoBindingResolver
 {
 public:
 
@@ -21,8 +21,6 @@ public:
     bool mouseEvent(Mouse::MouseEvent evt, int x, int y, int wheelDelta);
 
     void controlEvent(Control* control, EventType evt);
-
-    static bool resolveAutoBinding(const char* autoBinding, Node* node, MaterialParameter* parameter);
 
 protected:
 
@@ -49,9 +47,11 @@ private:
         MODE_DROP_BOX
     };
 
-    Vector3 getDirectionalLightDirection() const;
-    
-    Vector3 getDirectionalLightColor() const;
+    Vector3 getLight0DirectionWorld() const;
+    Vector3 getLight0DirectionView() const;
+    Vector3 getLight0Color() const;
+
+    bool resolveAutoBinding(const char* autoBinding, Node* node, MaterialParameter* parameter);
 
 	Font* _font;
 	Scene* _scene;


### PR DESCRIPTION
- Changed and simplified handling of custom material auto bindings by adding a new abstract class RenderState::AutoBindingResolver.
- Games can now simply extend this class and implement the one virtual function in it (resolveAutoBinding) to provide support for custom material auto bindings.
- Changed a common assertion/crash when running with an unset MaterialParameter to a warning. Unfortunately this is a potential per-draw-call warning, but a future change will provide a fix for all per-draw-call logging.
