### PR TITLE
Remove unused parameters from Effects, warning only once

### DIFF
--- a/gameplay/src/MaterialParameter.cpp
+++ b/gameplay/src/MaterialParameter.cpp
@@ -446,7 +446,7 @@ void MaterialParameter::setSamplerArray(const Texture::Sampler** values, unsigne
     _type = MaterialParameter::SAMPLER_ARRAY;
 }
 
-void MaterialParameter::bind(Effect* effect)
+bool MaterialParameter::bind(Effect* effect)
 {
     GP_ASSERT(effect);
 
@@ -459,8 +459,8 @@ void MaterialParameter::bind(Effect* effect)
         if (!_uniform)
         {
             // This parameter was not found in the specified effect, so do nothing.
-            GP_WARN("Warning: Material parameter '%s' not found in effect '%s'.", _name.c_str(), effect->getId());
-            return;
+            GP_WARN("Warning: Material parameter '%s' not found in effect '%s', removing...", _name.c_str(), effect->getId());
+            return false;
         }
     }
 
@@ -504,6 +504,7 @@ void MaterialParameter::bind(Effect* effect)
         GP_WARN("Unknown type (%d) for material parameter: %s", _type, _name.c_str());
         break;
     }
+    return true;
 }
 
 void MaterialParameter::bindValue(Node* node, const char* binding)

--- a/gameplay/src/MaterialParameter.h
+++ b/gameplay/src/MaterialParameter.h
@@ -430,7 +430,7 @@ private:
 
     void clearValue();
 
-    void bind(Effect* effect);
+    bool bind(Effect* effect);
 
     void applyAnimationValue(AnimationValue* value, float blendWeight, int components);
 

--- a/gameplay/src/RenderState.cpp
+++ b/gameplay/src/RenderState.cpp
@@ -418,7 +418,15 @@ void RenderState::bind(Pass* pass)
         for (size_t i = 0, count = rs->_parameters.size(); i < count; ++i)
         {
             GP_ASSERT(rs->_parameters[i]);
-            rs->_parameters[i]->bind(effect);
+            
+            // If this parameter cannot be found in the shader, drop it from this effect, printing the warning only once
+            if( !rs->_parameters[i]->bind(effect) ) {
+                removeParameter( _parameters[i]->getName() );
+                
+                // Since we removed the element at index i, we must revisit this index, and update count
+                i--;
+                count--;
+            }
         }
 
         if (rs->_state)


### PR DESCRIPTION
This pull request was motivated by the warning messages that get printed out every frame when a material has parameters set that the shader does not use.  This happens when parameters are set too widely or when uniforms are not used in a shader and get optimized out.

This pull request changes the behavior from printing out a warning every frame (due to the `bind()` call happening every frame) to printing out a warning once and then removing that unused parameter from that effect.  I am uncertain if this change is safe for materials with multiple passes where the parameter is set higher in the inheritance chain however, so I would appreciate some feedback on whether this is a good change or not.
