### PR TITLE
Revamp light falloff calculation in Encoder

### DIFF
--- a/tools/encoder/src/Light.cpp
+++ b/tools/encoder/src/Light.cpp
@@ -6,11 +6,7 @@ namespace gameplay
 
 Light::Light(void) :
     _lightType(0),
-    _constantAttenuation(0.0f),
-    _linearAttenuation(0.0f),
-    _quadraticAttenuation(0.0f),
-    _falloffExponent(0.0f),
-    _range(-1.0f),
+    _range(1.0f),
     _innerAngle(-1.0f),
     _outerAngle(0.0f)
 {
@@ -30,42 +26,11 @@ const char* Light::getElementName(void) const
     return "Light";
 }
 
-float Light::computeRange(float constantAttenuation, float linearAttenuation, float quadraticAttenuation)
-{
-    if (constantAttenuation == 0.0f && linearAttenuation == 0.0f && quadraticAttenuation == 0.0f)
-    {
-        return 0.0f;
-    }
-
-    // Constant Attenuation is currently not supported.
-    if (constantAttenuation == 1.0f)
-    {
-        return 1.0f;
-    }
-
-    const float step = 0.01f;
-    float range = 0.01f;
-    float att = 1.0f;
-    while (att > 0.01f)
-    {
-        att = 1 / (constantAttenuation + (range * linearAttenuation) + (range * range * quadraticAttenuation));
-        range += step;
-    }
-    return range;
-}
-
 void Light::writeBinary(FILE* file)
 {
     Object::writeBinary(file);
     write(_lightType, file);
     write(_color, COLOR_SIZE, file);
-
-    // Compute an approximate light range with Collada's attenuation parameters.
-    // This facilitates bringing in the light nodes directly from maya to gameplay.
-    if (_range == -1.0f)
-    {
-        _range = computeRange(_constantAttenuation, _linearAttenuation, _quadraticAttenuation);
-    }
 
     if (_lightType == SpotLight)
     {
@@ -84,13 +49,6 @@ void Light::writeText(FILE* file)
     fprintElementStart(file);
     fprintfElement(file, "lightType", _lightType);
     fprintfElement(file, "color", _color, COLOR_SIZE);
-
-    // Compute an approximate light range with Collada's attenuation parameters.
-    // This facilitates bringing in the light nodes directly from maya to gameplay.
-    if (_range == -1.0f)
-    {
-        _range = computeRange(_constantAttenuation, _linearAttenuation, _quadraticAttenuation);
-    }
 
     if (_lightType == SpotLight)
     {
@@ -147,18 +105,10 @@ void Light::setColor(float r, float g, float b)
     _color[1] = g;
     _color[2] = b;
 }
-
-void Light::setConstantAttenuation(float value)
+    
+void Light::setRange(float value)
 {
-    _constantAttenuation = value;
-}
-void Light::setLinearAttenuation(float value)
-{
-    _linearAttenuation = value;
-}
-void Light::setQuadraticAttenuation(float value)
-{
-    _quadraticAttenuation = value;
+    _range = value;
 }
 void Light::setInnerAngle(float value)
 {
@@ -167,14 +117,6 @@ void Light::setInnerAngle(float value)
 void Light::setOuterAngle(float value)
 {
     _outerAngle = value;
-}
-void Light::setFalloffExponent(float value)
-{
-    _falloffExponent = value;
-    if ( value != 1.0)
-    {
-        LOG(1, "Warning: spot light falloff_exponent must be 1.0. \n");
-    }
 }
 
 }

--- a/tools/encoder/src/Light.h
+++ b/tools/encoder/src/Light.h
@@ -44,12 +44,9 @@ public:
     void setColor(float r, float g, float b);
     void setColor(float r, float g, float b, float a);
 
-    void setConstantAttenuation(float value);
-    void setLinearAttenuation(float value);
-    void setQuadraticAttenuation(float value);
+    void setRange(float value);
     void setInnerAngle(float value);
     void setOuterAngle(float value);
-    void setFalloffExponent(float value);
 
     enum LightType
     {
@@ -66,11 +63,6 @@ private:
     
     unsigned char _lightType;
     float _color[COLOR_SIZE];
-
-    float _constantAttenuation;
-    float _linearAttenuation;
-    float _quadraticAttenuation;
-    float _falloffExponent;
 
     float _range;
     float _innerAngle;


### PR DESCRIPTION
- Remove Linear, Quadratic and Constant calculation from Light class
- Perform exact calculation of range rather than using approximation algorithm
- Remove falloffExponent as it was unused
- Default range parameter to 1.0f directly, rather than deferring until actually writing to the `.gpb` file

Please comment on these changes, I tried to clean up as much as I could, but I want to ensure that this doesn't break any functionality.  Additionally, I don't have Maya so I can't test the `DecayStart` code very well; Blender likes to encode things into `FarAttenuationEnd` as far as I can tell.
