### PR TITLE
Add conditionals in default shaders for using medium precision

### DIFF
--- a/gameplay/res/shaders/colored.frag
+++ b/gameplay/res/shaders/colored.frag
@@ -1,5 +1,9 @@
 #ifdef OPENGL_ES
+#ifdef OPENGL_ES_MEDIUMP
+precision mediump float;
+#else
 precision highp float;
+#endif
 #endif
 
 #ifndef DIRECTIONAL_LIGHT_COUNT

--- a/gameplay/res/shaders/font.frag
+++ b/gameplay/res/shaders/font.frag
@@ -1,6 +1,10 @@
 #ifdef OPENGL_ES
 #extension GL_OES_standard_derivatives : enable
+#ifdef OPENGL_ES_MEDIUMP
+precision mediump float;
+#else
 precision highp float;
+#endif
 #endif
 
 ///////////////////////////////////////////////////////////

--- a/gameplay/res/shaders/sprite.frag
+++ b/gameplay/res/shaders/sprite.frag
@@ -1,5 +1,9 @@
 #ifdef OPENGL_ES
+#ifdef OPENGL_ES_MEDIUMP
+precision mediump float;
+#else
 precision highp float;
+#endif
 #endif
 
 ///////////////////////////////////////////////////////////

--- a/gameplay/res/shaders/terrain.frag
+++ b/gameplay/res/shaders/terrain.frag
@@ -1,5 +1,9 @@
 #ifdef OPENGL_ES
+#ifdef OPENGL_ES_MEDIUMP
+precision mediump float;
+#else
 precision highp float;
+#endif
 #endif
 
 #ifndef DIRECTIONAL_LIGHT_COUNT

--- a/gameplay/res/shaders/textured.frag
+++ b/gameplay/res/shaders/textured.frag
@@ -1,5 +1,9 @@
 #ifdef OPENGL_ES
+#ifdef OPENGL_ES_MEDIUMP
+precision mediump float;
+#else
 precision highp float;
+#endif
 #endif
 
 #ifndef DIRECTIONAL_LIGHT_COUNT


### PR DESCRIPTION
Some devices have problems with high precision floats. I have tested
Nexus 4 and Nexus 7 with Android 4.4 having lightning artifacts when
using highp floats but work fine with mediump.
