### PR TITLE
Fixed missing copying of res/ui for BlackBerry samples

### DIFF
--- a/newproject.bat
+++ b/newproject.bat
@@ -203,6 +203,7 @@ call:replace "%projPath%\bar-descriptor.xml" TEMPLATE_TITLE "%title%"
 call:replace "%projPath%\bar-descriptor.xml" TEMPLATE_UUID "%uuid%"
 call:replace "%projPath%\bar-descriptor.xml" TEMPLATE_AUTHOR "%author%"
 call:replace "%projPath%\bar-descriptor.xml" TEMPLATE_DESCRIPTION "%desc%"
+call:replace "%projPath%\bar-descriptor.xml" GAMEPLAY_PATH "%gpPath%"
 
 REM Copy Android NDK project files
 mkdir "%projPath%\android"

--- a/newproject.sh
+++ b/newproject.sh
@@ -220,6 +220,7 @@ aliassedinplace "s*TEMPLATE_TITLE*$title*g" "$projPath/bar-descriptor.xml"
 aliassedinplace "s*TEMPLATE_UUID*$uuid*g" "$projPath/bar-descriptor.xml"
 aliassedinplace "s*TEMPLATE_AUTHOR*$author*g" "$projPath/bar-descriptor.xml"
 aliassedinplace "s*TEMPLATE_DESCRIPTION*$desc*g" "$projPath/bar-descriptor.xml"
+aliassedinplace "s*GAMEPLAY_PATH*$gpPath*g" "$projPath/bar-descriptor.xml"
 
 #############################################
 # Copy Android NDK project files

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -23,7 +23,6 @@ link_directories(
     ${CMAKE_SOURCE_DIR}/external-deps/glew/lib/linux/${ARCH_DIR}
 )
 
-
 set(GAMEPLAY_LIBRARIES
     gameplay
     m
@@ -56,5 +55,3 @@ add_subdirectory(mesh)
 add_subdirectory(particles)
 add_subdirectory(racer)
 add_subdirectory(spaceship)
-
-

--- a/samples/browser/bar-descriptor.xml
+++ b/samples/browser/bar-descriptor.xml
@@ -27,8 +27,7 @@
     <description>Samples</description>
 
     <!-- Name of author which is used for signing. Must match the developer name of your development certificate. -->
-    <author>Steve Grenier</author>
-    <authorId>gYAAgKe4iG8txlFg4PTJpbImmxI</authorId>
+    <author>RIM Canada</author>
 
     <!-- Unique author ID assigned by signing authority. Required if using debug tokens. -->
     <!-- <authorId>gYAAgPkLP1tZlyYP1wiMaRFFNMw</authorId> -->
@@ -45,6 +44,7 @@
     <asset path="icon.png">icon.png</asset>
 	<asset path="game.config">game.config</asset>
     <asset path="../../gameplay/res/shaders">res/shaders</asset>
+    <asset path="../../gameplay/res/ui">res/ui</asset>
 	<asset path="res/common">res/common</asset>
 	<asset path="res/png">res/png</asset>
 

--- a/samples/character/bar-descriptor.xml
+++ b/samples/character/bar-descriptor.xml
@@ -44,6 +44,7 @@
     <asset path="icon.png">icon.png</asset>
     <asset path="../../gameplay/res/logo_powered_white.png">res/logo_powered_white.png</asset>
     <asset path="../../gameplay/res/shaders">res/shaders</asset>
+    <asset path="../../gameplay/res/ui">res/ui</asset>
     <asset path="res/common">res/common</asset>
 
     <asset path="res/design/backboard.png">res/png/backboard.png</asset>

--- a/samples/lua/bar-descriptor.xml
+++ b/samples/lua/bar-descriptor.xml
@@ -45,9 +45,9 @@
     <asset path="game.config">game.config</asset>
    	<asset path="../../gameplay/res/logo_powered_white.png">res/logo_powered_white.png</asset>
     <asset path="../../gameplay/res/shaders">res/shaders</asset>
+    <asset path="../../gameplay/res/ui">res/ui</asset>
     <asset path="res/ai.lua">res/ai.lua</asset>
     <asset path="res/game.lua">res/game.lua</asset>
-    <asset path="res/arial.gpb">res/arial.gpb</asset>
     <asset path="res/lua.gpb">res/lua.gpb</asset>
     <asset path="res/lua.material">res/lua.material</asset>
     <asset path="res/lua.scene">res/lua.scene</asset>

--- a/samples/mesh/bar-descriptor.xml
+++ b/samples/mesh/bar-descriptor.xml
@@ -42,13 +42,13 @@
     <category>core.games</category>
     
     <asset path="icon.png">icon.png</asset>
-    <asset path="res/arial.gpb">res/arial.gpb</asset>
     <asset path="res/duck.png">res/duck.png</asset>
     <asset path="res/mesh.scene">res/mesh.scene</asset>
     <asset path="res/mesh.gpb">res/mesh.gpb</asset>
     <asset path="res/mesh.material">res/mesh.material</asset>
     <asset path="../../gameplay/res/logo_powered_white.png">res/logo_powered_white.png</asset>
     <asset path="../../gameplay/res/shaders">res/shaders</asset>
+    <asset path="../../gameplay/res/ui">res/ui</asset>
     <asset path="game.config">game.config</asset>
     
     <configuration name="Device-Debug">

--- a/samples/particles/bar-descriptor.xml
+++ b/samples/particles/bar-descriptor.xml
@@ -42,7 +42,6 @@
     <category>core.games</category>
 
     <asset path="icon.png">icon.png</asset>
-    <asset path="res/arial.gpb">res/arial.gpb</asset>
     <asset path="res/editor.form">res/editor.form</asset>
     <asset path="res/editor.png">res/editor.png</asset>
     <asset path="res/editor.theme">res/editor.theme</asset>
@@ -55,6 +54,7 @@
     <asset path="res/smoke.png">res/smoke.png</asset>
     <asset path="../../gameplay/res/logo_powered_white.png">res/logo_powered_white.png</asset>
     <asset path="../../gameplay/res/shaders">res/shaders</asset>
+    <asset path="../../gameplay/res/ui">res/ui</asset>
 
     <configuration name="Device-Debug">
        <platformArchitecture>armle-v7</platformArchitecture>

--- a/samples/racer/bar-descriptor.xml
+++ b/samples/racer/bar-descriptor.xml
@@ -44,6 +44,7 @@
     <asset path="icon.png">icon.png</asset>
     <asset path="../../gameplay/res/logo_powered_white.png">res/logo_powered_white.png</asset>
     <asset path="../../gameplay/res/shaders">res/shaders</asset>
+    <asset path="../../gameplay/res/ui">res/ui</asset>
     <asset path="res/common">res/common</asset>
         
     <configuration name="Device-Debug">

--- a/samples/spaceship/bar-descriptor.xml
+++ b/samples/spaceship/bar-descriptor.xml
@@ -22,12 +22,8 @@
   <asset path="res/propulsion_glow.png">res/propulsion_glow.png</asset>
   <asset path="../../gameplay/res/logo_powered_white.png">res/logo_powered_white.png</asset>
   <asset path="../../gameplay/res/shaders">res/shaders</asset>
+  <asset path="../../gameplay/res/ui">res/ui</asset>
   <asset path="game.config">game.config</asset>
-  <asset path="res/menu.form">res/menu.form</asset>
-  <asset path="res/menu.theme">res/menu.theme</asset>
-  <asset path="res/menuAtlas.png">res/menuAtlas.png</asset>
-  <asset path="res/challenge.form">res/challenge.form</asset>
-  <asset path="scoreloop">scoreloop</asset>
   <configuration name="Device-Debug">
     <platformArchitecture>armle-v7</platformArchitecture>
     <asset path="Device-Debug/sample-spaceship" entry="true" type="Qnx/Elf">sample-spaceship</asset>

--- a/template/template.bar-descriptor.xml
+++ b/template/template.bar-descriptor.xml
@@ -43,6 +43,8 @@
 
     <asset path="icon.png">icon.png</asset>
     <asset path="res">res</asset>
+    <asset path="GAMEPLAY_PATH/gameplay/res/shaders">res/shaders</asset>
+    <asset path="GAMEPLAY_PATH/gameplay/res/ui">res/ui</asset>
 
     <configuration name="Device-Debug">
        <platformArchitecture>armle-v7</platformArchitecture>


### PR DESCRIPTION
Removed unused copying of resources for samples
Updated bar-descriptor template so that it copies over res/shaders and res/ui
