### PR TITLE
Fix otherwise unset fragment alpha with VERTEX_COLOR defined.

### DIFF
--- a/gameplay/res/shaders/colored.frag
+++ b/gameplay/res/shaders/colored.frag
@@ -112,6 +112,7 @@ void main()
     
     #if defined(VERTEX_COLOR)
     gl_FragColor.rgb = v_color;
+    gl_FragColor.a = 1.0;
     #else
     gl_FragColor = u_diffuseColor;
     #endif


### PR DESCRIPTION
Otherwise, alpha component of the fragment defaults to 0.0 and causes missing triangles on some Android(and maybe other OS's too) devices.
