### PR TITLE
Check built-in preprocessor macros to see if highp is available

### DIFF
--- a/gameplay/res/shaders/colored.frag
+++ b/gameplay/res/shaders/colored.frag
@@ -1,8 +1,8 @@
 #ifdef OPENGL_ES
-#ifdef OPENGL_ES_MEDIUMP
-precision mediump float;
-#else
+#ifdef GL_FRAGMENT_PRECISION_HIGH
 precision highp float;
+#else
+precision mediump float;
 #endif
 #endif
 

--- a/gameplay/res/shaders/font.frag
+++ b/gameplay/res/shaders/font.frag
@@ -1,9 +1,9 @@
 #ifdef OPENGL_ES
 #extension GL_OES_standard_derivatives : enable
-#ifdef OPENGL_ES_MEDIUMP
-precision mediump float;
-#else
+#ifdef GL_FRAGMENT_PRECISION_HIGH
 precision highp float;
+#else
+precision mediump float;
 #endif
 #endif
 

--- a/gameplay/res/shaders/sprite.frag
+++ b/gameplay/res/shaders/sprite.frag
@@ -1,8 +1,8 @@
 #ifdef OPENGL_ES
-#ifdef OPENGL_ES_MEDIUMP
-precision mediump float;
-#else
+#ifdef GL_FRAGMENT_PRECISION_HIGH
 precision highp float;
+#else
+precision mediump float;
 #endif
 #endif
 

--- a/gameplay/res/shaders/terrain.frag
+++ b/gameplay/res/shaders/terrain.frag
@@ -1,8 +1,8 @@
 #ifdef OPENGL_ES
-#ifdef OPENGL_ES_MEDIUMP
-precision mediump float;
-#else
+#ifdef GL_FRAGMENT_PRECISION_HIGH
 precision highp float;
+#else
+precision mediump float;
 #endif
 #endif
 

--- a/gameplay/res/shaders/textured.frag
+++ b/gameplay/res/shaders/textured.frag
@@ -1,8 +1,8 @@
 #ifdef OPENGL_ES
-#ifdef OPENGL_ES_MEDIUMP
-precision mediump float;
-#else
+#ifdef GL_FRAGMENT_PRECISION_HIGH
 precision highp float;
+#else
+precision mediump float;
 #endif
 #endif
 


### PR DESCRIPTION
Replaces the previous patch I sent to add a flag to disable highp precision in fragment shaders. It turns out that GLSL has a macro to check that. I guess this is a better way to handle it.
