### PR TITLE
Corrected some calls to old functions of the FBX API

### DIFF
--- a/tools/encoder/src/FBXSceneEncoder.cpp
+++ b/tools/encoder/src/FBXSceneEncoder.cpp
@@ -442,10 +442,10 @@ void FBXSceneEncoder::loadAnimationLayer(FbxAnimLayer* fbxAnimLayer, FbxNode* fb
 
 void FBXSceneEncoder::loadAnimations(FbxScene* fbxScene, const EncoderArguments& arguments)
 {
-    FbxAnimEvaluator* evaluator = fbxScene->GetEvaluator();
+    FbxAnimEvaluator* evaluator = fbxScene->GetAnimationEvaluator();
     if (!evaluator)
         return;
-    FbxAnimStack* animStack = evaluator->GetContext();
+    FbxAnimStack* animStack = fbxScene->GetCurrentAnimationStack();
     if (!animStack)
         return;
 


### PR DESCRIPTION
These functions are not in the FBX API anymore (2014.2). It compiles thanks to these changes but I'm not sure this is correct since I don't know the FBX API. Please check and correct.
