### PR TITLE
Add background() and foreground() methods for Game class

### DIFF
--- a/gameplay/src/Game.cpp
+++ b/gameplay/src/Game.cpp
@@ -225,12 +225,17 @@ void Game::pause()
         _state = PAUSED;
         _pausedTimeLast = Platform::getAbsoluteTime();
         _animationController->pause();
-        _audioController->pause();
         _physicsController->pause();
         _aiController->pause();
     }
 
     ++_pausedCount;
+}
+
+void Game::background()
+{
+    if (_audioController)
+        _audioController->pause();
 }
 
 void Game::resume()
@@ -253,6 +258,12 @@ void Game::resume()
             _aiController->resume();
         }
     }
+}
+
+void Game::foreground()
+{
+    if (_audioController)
+        _audioController->resume();
 }
 
 void Game::exit()

--- a/gameplay/src/Game.h
+++ b/gameplay/src/Game.h
@@ -139,9 +139,21 @@ public:
     void pause();
 
     /**
+     * Called to release resources like audio when the application goes to
+     * background.
+     */
+    void background();
+
+    /**
      * Resumes the game after being paused.
      */
     void resume();
+
+    /**
+     * Called to claim back resources like audio when the application comes back
+     * to foreground.
+     */
+    void foreground();
 
     /**
      * Exits the game.

--- a/gameplay/src/PlatformAndroid.cpp
+++ b/gameplay/src/PlatformAndroid.cpp
@@ -1089,10 +1089,12 @@ static void engine_handle_cmd(struct android_app* app, int32_t cmd)
             if (__initialized)
             {
                 Game::getInstance()->resume();
+                Game::getInstance()->foreground();
             }
             __suspended = false;
             break;
         case APP_CMD_PAUSE:
+            Game::getInstance()->background();
             Game::getInstance()->pause();
             __suspended = true;
             break;

--- a/gameplay/src/PlatformBlackBerry.cpp
+++ b/gameplay/src/PlatformBlackBerry.cpp
@@ -1311,12 +1311,14 @@ int Platform::enterMessagePump()
                         if (!__screenFullscreen)
                             __screenFullscreen = true;
                         _game->resume();
+                        _game->foreground();
                         suspended = false;
                         break;
                     case NAVIGATOR_WINDOW_THUMBNAIL:
                     case NAVIGATOR_WINDOW_INVISIBLE:
                         if (__screenFullscreen && !suspended)
                         {
+                            _game->background();
                             _game->pause();
                             suspended = true;
                         }

--- a/gameplay/src/PlatformiOS.mm
+++ b/gameplay/src/PlatformiOS.mm
@@ -448,8 +448,10 @@ int getUnicode(int key);
         displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(update:)];
         [displayLink setFrameInterval:swapInterval];
         [displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
-        if (game)
+        if (game) {
             game->resume();
+            game->foreground();
+        }
         updating = TRUE;
     }
 }
@@ -458,8 +460,10 @@ int getUnicode(int key);
 {
     if (updating)
     {
-        if (game)
+        if (game) {
+            game->background();
             game->pause();
+        }
         [displayLink invalidate];
         displayLink = nil;
         updating = FALSE;


### PR DESCRIPTION
Currently there's no way to stop game loop without completely stopping
everything including audio. With this patch it is possible to continue
playing music in the background while the game is paused.
