### PR TITLE
Fixed breaking change in gameplay 2.0 which prevents DebugMem mode working properly

### DIFF
--- a/gameplay/src/PlatformWindows.cpp
+++ b/gameplay/src/PlatformWindows.cpp
@@ -346,7 +346,11 @@ LRESULT CALLBACK __WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
     switch (msg)
     {
     case WM_CLOSE:
-        exit(0);
+#if defined FORCE_CLEAN_SHUTDOWN || defined GP_USE_MEM_LEAK_DETECTION
+		DestroyWindow(__hwnd);
+#else
+		exit(0);
+#endif
         return 0;
 
     case WM_DESTROY:


### PR DESCRIPTION
Since gameplay 2.0, the Game class's finalize() method never gets called, even in DebugMem configuration, rendering the memory leak reports useless.

This change reverts to the gameplay 1.7 code where FORCE_CLEAN_SHUTDOWN or GP_USE_MEM_LEAK_DETECTION are defined.

NB: This change is for Windows only, as I do not currently have an installation of gameplay on Linux.
