### PR TITLE
Allow clearing all scheduled events using Game::clearSchedule

### DIFF
--- a/gameplay/src/Game.cpp
+++ b/gameplay/src/Game.cpp
@@ -548,6 +548,12 @@ void Game::schedule(float timeOffset, const char* function)
     schedule(timeOffset, listener, NULL);
 }
 
+void Game::clearSchedule()
+{
+    SAFE_DELETE(_timeEvents);
+    _timeEvents = new std::priority_queue<TimeEvent, std::vector<TimeEvent>, std::less<TimeEvent> >();
+}
+
 void Game::fireTimeEvents(double frameTime)
 {
     while (_timeEvents->size() > 0)

--- a/gameplay/src/Game.h
+++ b/gameplay/src/Game.h
@@ -599,6 +599,11 @@ public:
     void schedule(float timeOffset, const char* function);
 
     /**
+     * Clears all scheduled time events.
+     */
+    void clearSchedule();
+
+    /**
      * Opens an URL in an external browser, if available.
      *
      * @param url URL to be opened.

--- a/gameplay/src/lua/lua_Game.cpp
+++ b/gameplay/src/lua/lua_Game.cpp
@@ -27,6 +27,7 @@ void luaRegister_Game()
     {
         {"canExit", lua_Game_canExit},
         {"clear", lua_Game_clear},
+        {"clearSchedule", lua_Game_clearSchedule},
         {"displayKeyboard", lua_Game_displayKeyboard},
         {"exit", lua_Game_exit},
         {"frame", lua_Game_frame},
@@ -267,6 +268,38 @@ int lua_Game_clear(lua_State* state)
         default:
         {
             lua_pushstring(state, "Invalid number of parameters (expected 5 or 8).");
+            lua_error(state);
+            break;
+        }
+    }
+    return 0;
+}
+
+int lua_Game_clearSchedule(lua_State* state)
+{
+    // Get the number of parameters.
+    int paramCount = lua_gettop(state);
+
+    // Attempt to match the parameters to a valid binding.
+    switch (paramCount)
+    {
+        case 1:
+        {
+            if ((lua_type(state, 1) == LUA_TUSERDATA))
+            {
+                Game* instance = getInstance(state);
+                instance->clearSchedule();
+                
+                return 0;
+            }
+
+            lua_pushstring(state, "lua_Game_clearSchedule - Failed to match the given parameters to a valid function signature.");
+            lua_error(state);
+            break;
+        }
+        default:
+        {
+            lua_pushstring(state, "Invalid number of parameters (expected 1).");
             lua_error(state);
             break;
         }

--- a/gameplay/src/lua/lua_Game.h
+++ b/gameplay/src/lua/lua_Game.h
@@ -8,6 +8,7 @@ namespace gameplay
 int lua_Game__gc(lua_State* state);
 int lua_Game_canExit(lua_State* state);
 int lua_Game_clear(lua_State* state);
+int lua_Game_clearSchedule(lua_State* state);
 int lua_Game_displayKeyboard(lua_State* state);
 int lua_Game_exit(lua_State* state);
 int lua_Game_frame(lua_State* state);


### PR DESCRIPTION
This is useful when having invalidated or deleted event listeners, such as game state objects (menus, levels, player stats)
