### PR TITLE
Fix vector assignment in terrain.frag

### DIFF
--- a/gameplay/res/shaders/terrain.frag
+++ b/gameplay/res/shaders/terrain.frag
@@ -133,7 +133,7 @@ void main()
 
     #else
 
-    gl_FragColor.rgb = _baseColor;
+    gl_FragColor.rgb = _baseColor.rgb;
 
     #endif
 }


### PR DESCRIPTION
Apparently some drivers are picky about this.

Fixes #1449
