### PR TITLE
Add support for creation of OSX App Delegate class via game.config setting.

### DIFF
--- a/samples/mesh/Credits.rtf
+++ b/samples/mesh/Credits.rtf
@@ -1,0 +1,7 @@
+{\rtf1\ansi\ansicpg1252\cocoartf1265\cocoasubrtf190
+\cocoascreenfonts1{\fonttbl\f0\fswiss\fcharset0 Helvetica;}
+{\colortbl;\red255\green255\blue255;}
+\paperw11900\paperh16840\vieww16020\viewh8400\viewkind0
+\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\qc
+
+\f0\b\fs24 \cf0 Powered by {\field{\*\fldinst{HYPERLINK "http://gameplay3d.org"}}{\fldrslt GamePlay}}}

--- a/samples/mesh/game.config
+++ b/samples/mesh/game.config
@@ -1,3 +1,8 @@
+app
+{
+    delegateClass = AppDelegate
+}
+
 window
 {
     title = Mesh

--- a/samples/mesh/sample-mesh.xcodeproj/project.pbxproj
+++ b/samples/mesh/sample-mesh.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		5B04C5E114BFE1A200EB0071 /* res in Resources */ = {isa = PBXBuildFile; fileRef = 42A3C5DD146C96640091C1E4 /* res */; };
 		5B04C5E214BFE1A200EB0071 /* icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 42CCD4B3146D914B00353661 /* icon.png */; };
 		6212DAB21829D99A006213DD /* GameKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6212DAB11829D999006213DD /* GameKit.framework */; };
+		A14611AB18CA39D1000D75B4 /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = A14611A918CA39D1000D75B4 /* AppDelegate.mm */; };
+		A14A48AD18CA672E00A95BC0 /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = A14A48AC18CA672E00A95BC0 /* Credits.rtf */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -83,6 +85,9 @@
 		42F68AA61469CDE100E0E3C4 /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = System/Library/Frameworks/OpenGL.framework; sourceTree = SDKROOT; };
 		5B04C5E614BFE1A200EB0071 /* sample-mesh-ios.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "sample-mesh-ios.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6212DAB11829D999006213DD /* GameKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GameKit.framework; path = System/Library/Frameworks/GameKit.framework; sourceTree = SDKROOT; };
+		A14611A818CA39D1000D75B4 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = src/AppDelegate.h; sourceTree = SOURCE_ROOT; };
+		A14611A918CA39D1000D75B4 /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AppDelegate.mm; path = src/AppDelegate.mm; sourceTree = SOURCE_ROOT; };
+		A14A48AC18CA672E00A95BC0 /* Credits.rtf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.rtf; path = Credits.rtf; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -133,6 +138,7 @@
 		4217005314697FF100A45C02 = {
 			isa = PBXGroup;
 			children = (
+				A14A48AC18CA672E00A95BC0 /* Credits.rtf */,
 				42F237A516AD9D720019CAC9 /* Default-568h@2x.png */,
 				42F68AA31469CC3000E0E3C4 /* sample-mesh-macosx.plist */,
 				42458CB514C3AB1600EFFB61 /* sample-mesh-ios.plist */,
@@ -158,6 +164,8 @@
 		4217006814697FF100A45C02 /* src */ = {
 			isa = PBXGroup;
 			children = (
+				A14611A818CA39D1000D75B4 /* AppDelegate.h */,
+				A14611A918CA39D1000D75B4 /* AppDelegate.mm */,
 				42BBCD32146C89F900D2A5F8 /* MeshGame.cpp */,
 				42BBCD33146C89F900D2A5F8 /* MeshGame.h */,
 			);
@@ -311,6 +319,7 @@
 				42CCD4B4146D914B00353661 /* icon.png in Resources */,
 				42B7027815B0B278002BB8C3 /* game.config in Resources */,
 				42A3C5DE146C96640091C1E4 /* res in Resources */,
+				A14A48AD18CA672E00A95BC0 /* Credits.rtf in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -362,6 +371,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				42BBCD34146C89F900D2A5F8 /* MeshGame.cpp in Sources */,
+				A14611AB18CA39D1000D75B4 /* AppDelegate.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/samples/mesh/src/AppDelegate.h
+++ b/samples/mesh/src/AppDelegate.h
@@ -1,0 +1,11 @@
+//
+// Example NSApplicationDelegate implementation.
+//
+// Andy Duplain <andy@trojanfoe.com>, March 2014.
+//
+
+#import <AppKit/AppKit.h>
+
+@interface AppDelegate : NSObject <NSApplicationDelegate>
+@end
+

--- a/samples/mesh/src/AppDelegate.mm
+++ b/samples/mesh/src/AppDelegate.mm
@@ -1,0 +1,51 @@
+//
+// Example NSApplicationDelegate implementation.
+//
+// Andy Duplain <andy@trojanfoe.com>, March 2014.
+//
+
+#import <sys/types.h>
+#import <sys/sysctl.h>
+#import "AppDelegate.h"
+#import "Base.h"
+#import "Game.h"
+
+using namespace gameplay;
+
+@implementation AppDelegate
+
+#pragma mark - NSApplicationDelegate methods
+
+- (void)applicationWillFinishLaunching:(NSNotification*)notification
+{
+    //
+    // From: http://www.cocoawithlove.com/2010/09/minimalist-cocoa-programming.html
+    //
+    NSMenu* menubar = [[NSMenu new] autorelease];
+    NSMenuItem* appMenuItem = [[NSMenuItem new] autorelease];
+    [menubar addItem:appMenuItem];
+    [NSApp setMainMenu:menubar];
+    NSMenu* appMenu = [[NSMenu new] autorelease];
+    NSString* appName = [[NSProcessInfo processInfo] processName];
+    NSString* aboutTitle = [@"About " stringByAppendingString:appName];
+    NSMenuItem* aboutMenuItem = [[[NSMenuItem alloc] initWithTitle:aboutTitle
+                                                  action:@selector(orderFrontStandardAboutPanel:)
+                                                     keyEquivalent:@""] autorelease];
+    [appMenu addItem:aboutMenuItem];
+
+    NSString* quitTitle = [@"Quit " stringByAppendingString:appName];
+    NSMenuItem* quitMenuItem = [[[NSMenuItem alloc] initWithTitle:quitTitle
+                                                           action:@selector(terminate:)
+                                                    keyEquivalent:@"q"] autorelease];
+    [appMenu addItem:quitMenuItem];
+    [appMenuItem setSubmenu:appMenu];
+}
+
+- (void)applicationWillTerminate:(NSNotification *)notification
+{
+    Game* game = Game::getInstance();
+    game->exit();
+}
+
+@end
+

--- a/tools/encoder/gameplay-encoder.xcodeproj/project.pbxproj
+++ b/tools/encoder/gameplay-encoder.xcodeproj/project.pbxproj
@@ -13,7 +13,7 @@
 		422BF0861804C16E0028D009 /* libm.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 422BF0851804C16E0028D009 /* libm.dylib */; };
 		422BF0881804C1E40028D009 /* libbz2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 422BF0871804C1E40028D009 /* libbz2.dylib */; };
 		422BF0901804C5230028D009 /* libstdc++.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 422BF08F1804C5230028D009 /* libstdc++.dylib */; };
-		422BF0921804C7060028D009 /* libfbxsdk-static.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 422BF0911804C7060028D009 /* libfbxsdk-static.a */; };
+		422BF0921804C7060028D009 /* libfbxsdk.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 422BF0911804C7060028D009 /* libfbxsdk.a */; };
 		4251B12C152D044B002F6199 /* Curve.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4251B128152D044B002F6199 /* Curve.cpp */; };
 		4262783C180491D60015672B /* edtaa3func.c in Sources */ = {isa = PBXBuildFile; fileRef = 4262783A180491D60015672B /* edtaa3func.c */; };
 		42783423148D6F7500A6E27F /* FBXSceneEncoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4278341E148D6F7500A6E27F /* FBXSceneEncoder.cpp */; };
@@ -85,7 +85,7 @@
 		422BF0851804C16E0028D009 /* libm.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libm.dylib; path = ../../../../../../usr/lib/libm.dylib; sourceTree = "<group>"; };
 		422BF0871804C1E40028D009 /* libbz2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libbz2.dylib; path = ../../../../../../usr/lib/libbz2.dylib; sourceTree = "<group>"; };
 		422BF08F1804C5230028D009 /* libstdc++.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libstdc++.dylib"; path = "../../../../../../usr/lib/libstdc++.dylib"; sourceTree = "<group>"; };
-		422BF0911804C7060028D009 /* libfbxsdk-static.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libfbxsdk-static.a"; path = "../../../../../../Applications/Autodesk/FBX SDK/2014.2.1/lib/gcc4/ub/release/libfbxsdk-static.a"; sourceTree = "<group>"; };
+		422BF0911804C7060028D009 /* libfbxsdk.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libfbxsdk.a"; path = "../../../../../../Applications/Autodesk/FBX SDK/2014.2.1/lib/clang/ub/release/libfbxsdk.a"; sourceTree = "<group>"; };
 		42475CE6147208A000610A6A /* gameplay-encoder */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "gameplay-encoder"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4251B128152D044B002F6199 /* Curve.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Curve.cpp; path = src/Curve.cpp; sourceTree = SOURCE_ROOT; };
 		4251B129152D044B002F6199 /* Curve.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Curve.h; path = src/Curve.h; sourceTree = SOURCE_ROOT; };
@@ -200,7 +200,7 @@
 				42C0CE9C1804829E006B2F23 /* libpng.a in Frameworks */,
 				4228A3FF1620A5A300955433 /* Cocoa.framework in Frameworks */,
 				422BF0901804C5230028D009 /* libstdc++.dylib in Frameworks */,
-				422BF0921804C7060028D009 /* libfbxsdk-static.a in Frameworks */,
+				422BF0921804C7060028D009 /* libfbxsdk.a in Frameworks */,
 				422BF0881804C1E40028D009 /* libbz2.dylib in Frameworks */,
 				422BF0861804C16E0028D009 /* libm.dylib in Frameworks */,
 				42C0CE9E180482B8006B2F23 /* libfreetype.a in Frameworks */,
@@ -355,7 +355,7 @@
 				42C8EE381472DAA300E43619 /* libz.dylib */,
 				42C8EE361472D7E700E43619 /* libxml2.dylib */,
 				4228A4021620A63F00955433 /* libiconv.dylib */,
-				422BF0911804C7060028D009 /* libfbxsdk-static.a */,
+				422BF0911804C7060028D009 /* libfbxsdk.a */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -501,7 +501,7 @@
 				);
 				INFOPLIST_PREPROCESSOR_DEFINITIONS = "";
 				LIBRARY_SEARCH_PATHS = (
-					"\"/Applications/Autodesk/FBX SDK/2014.2.1/lib/gcc4/ub/release\"",
+					"\"/Applications/Autodesk/FBX SDK/2014.2.1/lib/clang/ub/release\"",
 					"../../external-deps/png/lib/macosx",
 					"../../external-deps/freetype2/lib/macosx",
 				);
@@ -549,7 +549,7 @@
 				);
 				INFOPLIST_PREPROCESSOR_DEFINITIONS = "";
 				LIBRARY_SEARCH_PATHS = (
-					"\"/Applications/Autodesk/FBX SDK/2014.2.1/lib/gcc4/ub/release\"",
+					"\"/Applications/Autodesk/FBX SDK/2014.2.1/lib/clang/ub/release\"",
 					"../../external-deps/png/lib/macosx",
 					"../../external-deps/freetype2/lib/macosx",
 				);
@@ -578,8 +578,8 @@
 					"$(inherited)",
 					"../../external-deps/freetype2/lib/macosx",
 					"../../external-deps/png/lib/macosx",
-					"/Applications/Autodesk/FBX\\ SDK/2014.2.1/lib/gcc4/ub/release",
-					"$(SYSTEM_APPS_DIR)/Autodesk/FBX\\ SDK/2014.2.1/lib/gcc4/ub/release",
+					"/Applications/Autodesk/FBX\\ SDK/2014.2.1/lib/clang/ub/release",
+					"$(SYSTEM_APPS_DIR)/Autodesk/FBX\\ SDK/2014.2.1/lib/clang/ub/release",
 				);
 				MACH_O_TYPE = mh_execute;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -603,8 +603,8 @@
 					"../../external-deps/freetype2/lib/macosx",
 					"../../external-deps/png/lib/macosx",
 					/Applications/Autodesk/FBX,
-					SDK/2014.2.1/lib/gcc4/ub/release,
-					"$(SYSTEM_APPS_DIR)/Autodesk/FBX\\ SDK/2014.2.1/lib/gcc4/ub/release",
+					SDK/2014.2.1/lib/clang/ub/release,
+					"$(SYSTEM_APPS_DIR)/Autodesk/FBX\\ SDK/2014.2.1/lib/clang/ub/release",
 				);
 				MACH_O_TYPE = mh_execute;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
This allows the OSX App to create an application menu in its app delegate class,
including an About Box and support for quiting via Cmd-Q.

New game.config namespace "app" with a single supported value "delegateClass" specifying
the Objective-C class.

The "mesh" sample implements an example App Delegate.
