### PR TITLE
Fixed TextBox to allow listeners to receive the TEXT_CHANGED event.

### DIFF
--- a/gameplay/src/Form.cpp
+++ b/gameplay/src/Form.cpp
@@ -738,8 +738,6 @@ bool Form::keyEventInternal(Keyboard::KeyEvent evt, int key)
             __shiftKeyDown = false;
         break;
     }
-    if (key == Keyboard::KEY_ESCAPE)
-        return false;
 
     // Handle focus changing
     if (__focusControl)

--- a/gameplay/src/TextBox.cpp
+++ b/gameplay/src/TextBox.cpp
@@ -4,11 +4,6 @@
 namespace gameplay
 {
 
-static bool space(char c)
-{
-    return isspace(c);
-}
-
 TextBox::TextBox() : _caretLocation(0), _lastKeypress(0), _fontSize(0), _caretImage(NULL), _passwordChar('*'), _inputMode(TEXT), _ctrlPressed(false)
 {
     _canFocus = true;
@@ -31,6 +26,16 @@ Control* TextBox::create(Theme::Style* style, Properties* properties)
     TextBox* textBox = new TextBox();
     textBox->initialize("TextBox", style, properties);
     return textBox;
+}
+
+void TextBox::addListener(Control::Listener* listener, int eventFlags)
+{
+    if ((eventFlags & Control::Listener::VALUE_CHANGED) == Control::Listener::VALUE_CHANGED)
+    {
+        GP_ERROR("VALUE_CHANGED event is not applicable to this control.");
+    }
+
+    Control::addListener(listener, eventFlags);
 }
 
 void TextBox::initialize(const char* typeName, Theme::Style* style, Properties* properties)
@@ -62,22 +67,18 @@ void TextBox::setCaretLocation(unsigned int index)
 
 bool TextBox::touchEvent(Touch::TouchEvent evt, int x, int y, unsigned int contactIndex)
 {
-    State state = getState();
-
-    switch (evt)
-    {
-    case Touch::TOUCH_PRESS: 
-        if (state == ACTIVE)
+    if (getState() == ACTIVE) {
+        switch (evt)
         {
+        case Touch::TOUCH_PRESS:
             setCaretLocation(x, y);
-        }
-        break;
-    case Touch::TOUCH_MOVE:
-        if (state == ACTIVE)
-        {
+            break;
+        case Touch::TOUCH_MOVE:
             setCaretLocation(x, y);
+            break;
+        default:
+            break;
         }
-        break;
     }
 
     return Label::touchEvent(evt, x, y, contactIndex);
@@ -302,6 +303,8 @@ void TextBox::controlEvent(Control::Listener::EventType evt)
 
     case Control::Listener::FOCUS_LOST:
         Game::getInstance()->displayKeyboard(false);
+        break;
+    default:
         break;
     }
 }

--- a/gameplay/src/TextBox.h
+++ b/gameplay/src/TextBox.h
@@ -1,10 +1,9 @@
 #ifndef TEXTBOX_H_
 #define TEXTBOX_H_
 
-#include "Base.h"
+#include <string>
+
 #include "Label.h"
-#include "Theme.h"
-#include "Keyboard.h"
 
 namespace gameplay
 {
@@ -106,6 +105,8 @@ public:
      * @return The input mode.
      */
     InputMode getInputMode() const;
+
+    virtual void addListener(Control::Listener* listener, int eventFlags);
 
 protected:
 


### PR DESCRIPTION
I had started changing the cmake build system but before changing something more
major like that I wanted to see if what I had in mind would work.

The thing that prompted me to look at the build system in the first place is
that I couldn't build gameplay as a 64-bit app on OS X because the Bullet
library was 32-bit. Cmake comes with its own set of scripts to find libraries
installed on the host OS with the exception of some of the ones needed for Linux
and oggvorbis but it shouldn't be too hard to write something to find them too.
By relying on cmake to find the libraries a lot of the build scripts could be
simplified and the pre-built libraries wouldn't have to be maintained as much.
The search path can be customized so pre-built libraries could still be
distributed for those who don't want to figure out how to install the libraries
for their OS or as a fallback.
