### PR TITLE
fix build error (typo)

### DIFF
--- a/gameplay/src/RenderState.h
+++ b/gameplay/src/RenderState.h
@@ -222,7 +222,7 @@ public:
     enum FrontFace
     {
         FRONT_FACE_CW = GL_CW,
-        FRONT_FACE_CC = GL_CCW
+        FRONT_FACE_CCW = GL_CCW
     };
 
 	/**


### PR DESCRIPTION
fixes a typo that was causing a build error in gameplay
