### PR TITLE
Audiosource errors

### DIFF
--- a/gameplay/src/AudioSource.cpp
+++ b/gameplay/src/AudioSource.cpp
@@ -30,13 +30,14 @@ AudioSource::~AudioSource()
 {
     if (_alSource)
     {
-        if (getState() == PLAYING || getState() == STOPPED)
-        {
-            // Remove the source from the controller's set of currently playing sources.
-            AudioController* audioController = Game::getInstance()->getAudioController();
-            GP_ASSERT(audioController);
-            audioController->removePlayingSource(this);
-        }
+        // Remove the source from the controller's set of currently playing sources
+        // regardless of the source's state. E.g. when the AudioController::pause is called
+        // all sources are paused but still remain in controller's set of currently 
+        // playing sources. When the source is deleted afterwards, it should be removed
+        // from controller's set regardless of its playing state.
+        AudioController* audioController = Game::getInstance()->getAudioController();
+        GP_ASSERT(audioController);
+        audioController->removePlayingSource(this);
 
         AL_CHECK(alDeleteSources(1, &_alSource));
         _alSource = 0;


### PR DESCRIPTION
I found two issues after audio streaming support was merged. First, alDeleteSources code was accidentally removed after merge and runtime error is appearing when trying to delete playing source. Second, there were a crash, when trying to delete paused streamed sources.
