### PR TITLE
Fix text rendering on non-integer x position.

### DIFF
--- a/gameplay/src/Font.cpp
+++ b/gameplay/src/Font.cpp
@@ -351,7 +351,7 @@ Font::Text* Font::createText(const char* text, const Rectangle& area, const Vect
                     truncated = true;
                     break;
                 }
-                else if (xPos >= area.x)
+                else if (xPos >= (int)area.x)
                 {
                     // Draw this character.
                     if (draw)
@@ -784,7 +784,7 @@ void Font::drawText(const char* text, const Rectangle& area, const Vector4& colo
                     truncated = true;
                     break;
                 }
-                else if (xPos >= area.x)
+                else if (xPos >= (int)area.x)
                 {
                     // Draw this character.
                     if (draw)


### PR DESCRIPTION
Rendering at non-integer x position makes first character of every line
disappear. It is because the position gets rounded down to integer and later
compared against the original float. First character then seem to be out of
the text area.
