### PR TITLE
Fix leak in ParticleEmitter

### DIFF
--- a/gameplay/src/ParticleEmitter.cpp
+++ b/gameplay/src/ParticleEmitter.cpp
@@ -54,7 +54,9 @@ ParticleEmitter* ParticleEmitter::create(const char* textureFile, TextureBlendin
     GP_ASSERT(texture->getWidth());
     GP_ASSERT(texture->getHeight());
 
-    return ParticleEmitter::create(texture, textureBlending, particleCountMax);
+    ParticleEmitter* emitter =  ParticleEmitter::create(texture, textureBlending, particleCountMax);
+    SAFE_RELEASE(texture);
+    return emitter;
 }
 
 ParticleEmitter* ParticleEmitter::create(Texture* texture, TextureBlending textureBlending,  unsigned int particleCountMax)


### PR DESCRIPTION
Texture was not being released when creating a new ParticleEmitter. This affects both Master and Next branches
