### PR TITLE
Fix TerrainPatch leaking camera

### DIFF
--- a/gameplay/src/TerrainPatch.cpp
+++ b/gameplay/src/TerrainPatch.cpp
@@ -48,6 +48,7 @@ TerrainPatch::~TerrainPatch()
     {
         deleteLayer(*_layers.begin());
     }
+    SAFE_RELEASE(_camera);
 }
 
 TerrainPatch* TerrainPatch::create(Terrain* terrain, unsigned int index,


### PR DESCRIPTION
When drawing terrain the scene camera is leaked with various reference counts, depending on the patches used to create the terrain. This appears to fix it. Probably also affects Next branch, but I haven't tested it. Can create a PR if needed.
