### PR TITLE
Fix support for old iOS sdks (namely iOS 7.1 SDK)

### DIFF
--- a/gameplay/src/PlatformiOS.mm
+++ b/gameplay/src/PlatformiOS.mm
@@ -1511,29 +1511,33 @@ bool Platform::canExit()
 
 unsigned int Platform::getDisplayWidth()
 {
-    if(NSFoundationVersionNumber <= NSFoundationVersionNumber_iOS_7_1)
-    {
-        CGSize size = DeviceOrientedSize([__appDelegate.viewController interfaceOrientation]);
-        return size.width;
-    }
-    else
+#ifdef NSFoundationVersionNumber_iOS_7_1
+    if (NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_7_1)
     {
         //iOS 8+
         return [[UIScreen mainScreen] bounds].size.width * [[UIScreen mainScreen] scale];
+    }
+    else
+#endif
+    {
+        CGSize size = DeviceOrientedSize([__appDelegate.viewController interfaceOrientation]);
+        return size.width;
     }
 }
 
 unsigned int Platform::getDisplayHeight()
 {
-    if(NSFoundationVersionNumber <= NSFoundationVersionNumber_iOS_7_1)
-    {
-        CGSize size = DeviceOrientedSize([__appDelegate.viewController interfaceOrientation]);
-        return size.height;
-    }
-    else
+#ifdef NSFoundationVersionNumber_iOS_7_1
+    if (NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_7_1)
     {
         //iOS 8+
         return [[UIScreen mainScreen] bounds].size.height * [[UIScreen mainScreen] scale];
+    }
+    else
+#endif
+    {
+        CGSize size = DeviceOrientedSize([__appDelegate.viewController interfaceOrientation]);
+        return size.height;
     }
 }
 


### PR DESCRIPTION
We still have until February 1st, 2015 to submit apps with iOS 7.1 [1]. So whilst it's trivial to support we might as well continue to support the iOS 7.1 SDK.

[1] http://9to5mac.com/2014/10/20/apple-to-require-ios-apps-and-updates-to-use-ios-8-sdk-and-include-64-bit-support-from-february-2015/
