### PR TITLE
Add 1 pixel padding to generated font atlas

### DIFF
--- a/tools/encoder/src/TTFFontEncoder.cpp
+++ b/tools/encoder/src/TTFFontEncoder.cpp
@@ -316,7 +316,7 @@ int writeFont(const char* inFilePath, const char* outFilePath, std::vector<unsig
         // Allocate temporary image buffer to draw the glyphs into.
         unsigned char* imageBuffer = (unsigned char*)malloc(imageWidth * imageHeight);
         memset(imageBuffer, 0, imageWidth * imageHeight);
-        penX = 0;
+        penX = 1;
         penY = 0;
         row = 0;
         i = 0;
@@ -339,7 +339,7 @@ int writeFont(const char* inFilePath, const char* outFilePath, std::vector<unsig
             // If we reach the end of the image wrap aroud to the next row.
             if ((penX + advance) > (int)imageWidth)
             {
-                penX = 0;
+                penX = 1;
                 row += 1;
                 penY = row * rowSize;
                 if (penY + rowSize > (int)imageHeight)


### PR DESCRIPTION
This avoids artifacts when using SDF fonts with some characters that
happen to be on the first column of the texture atlas.

Example: https://www.dropbox.com/s/6t6edr0w4enyvdm/Screenshot%202015-01-01%2016.55.02.png?dl=0 (left side of p, 7 and K is not smooth)

Fixed: https://www.dropbox.com/s/w4ha6824j6j8s15/Screenshot%202015-01-01%2016.55.51.png?dl=0