### PR TITLE
Fix for PhysicsVehicleWheel::findAncestorAndBind() 

### DIFF
--- a/gameplay/src/PhysicsVehicleWheel.cpp
+++ b/gameplay/src/PhysicsVehicleWheel.cpp
@@ -129,8 +129,8 @@ void PhysicsVehicleWheel::findAncestorAndBind()
     Node* m;
     for (Node* n = getNode(); n && !host; n = n->getParent())
     {
-        // Visit siblings before n
-        for (m = n->getPreviousSibling(); m && !host; m = m->getPreviousSibling())
+        // Visit siblings previous siblings starting with n
+        for (m = n; m && !host; m = m->getPreviousSibling())
         {
             host = findVehicle(m);
         }


### PR DESCRIPTION
PhysicsVechicles didn't seem to support a node hierarchy case where the PhysicsVechicle node is the direct / immediate parent of the PhysicsVehicleWheel node. The node traversal now includes the parent node.