### PR TITLE
SpriteSample loads a majority of it's content from a .scene file.

### DIFF
--- a/gameplay/src/Sprite.cpp
+++ b/gameplay/src/Sprite.cpp
@@ -246,12 +246,14 @@ Sprite* Sprite::create(Properties* properties)
     float heightPercentage = 0.0f;
     if (properties->exists("width"))
     {
-        if (properties->getType("width") == Properties::NUMBER) //TODO: Verify that this works for "100" but fails for "100%"
+        if (properties->getType("width") == Properties::NUMBER)
         {
+			// Number only (200)
             width = properties->getFloat("width");
         }
         else
         {
+			// Number and something else (200%)
             widthPercentage = properties->getFloat("width") / 100.0f;
         }
     }

--- a/gameplay/src/TileSet.cpp
+++ b/gameplay/src/TileSet.cpp
@@ -136,7 +136,7 @@ TileSet* TileSet::create(Properties* properties)
             Vector2 cell;
             Vector2 source;
             if (tileProperties->getVector2("cell", &cell) && tileProperties->getVector2("source", &source) &&
-                (cell.x > 0 && cell.y > 0 && cell.x < set->_columnCount && cell.y < set->_rowCount))
+                (cell.x >= 0 && cell.y >= 0 && cell.x < set->_columnCount && cell.y < set->_rowCount))
             {
                 set->_tiles[(int)cell.y * set->_columnCount + (int)cell.x] = source;
             }

--- a/samples/browser/res/common/sprites/sprite.scene
+++ b/samples/browser/res/common/sprites/sprite.scene
@@ -1,0 +1,199 @@
+scene spriteSampleScene
+{
+	// Width and height are expected to be 1280x720
+
+	node camera
+	{
+		camera
+		{
+			type = ORTHOGRAPHIC
+			nearPlane = 0
+			farPlane = 100
+
+			// zoomX default is game width
+			// zoomY default is game height
+			// aspectRatio default is game width / game height
+		}
+
+		// width and height are divided in half
+		translate = 640, 360, 0
+	}
+
+	// Background sprite
+	node background
+	{
+		sprite
+		{
+			path = res/common/sprites/background.png
+
+			// game width * 5
+			width = 6400
+			height = 720
+		}
+	}
+
+	// Level floor
+	node floor
+	{
+		tileset
+		{
+			path = res/common/sprites/level.png
+
+			tileWidth = 70
+			tileHeight = 70
+
+			rows = 3
+			columns = 7
+
+			tile
+			{
+				cell = 0, 0
+				source = 568, 284
+			}
+			tile
+			{
+				cell = 1, 0
+				source = 568, 284
+			}
+			tile
+			{
+				cell = 2, 0
+				source = 568, 284
+			}
+			tile
+			{
+				cell = 3, 0
+				source = 568, 284
+			}
+			tile
+			{
+				cell = 4, 0
+				source = 497, 284
+			}
+
+			tile
+			{
+				cell = 0, 1
+				source = 568, 0
+			}
+			tile
+			{
+				cell = 1, 1
+				source = 568, 0
+			}
+			tile
+			{
+				cell = 2, 1
+				source = 568, 0
+			}
+			tile
+			{
+				cell = 3, 1
+				source = 568, 0
+			}
+			tile
+			{
+				cell = 4, 1
+				source = 710, 142
+			}
+			tile
+			{
+				cell = 5, 1
+				source = 497, 284
+			}
+
+			tile
+			{
+				cell = 0, 2
+				source = 568, 0
+			}
+			tile
+			{
+				cell = 1, 2
+				source = 568, 0
+			}
+			tile
+			{
+				cell = 2, 2
+				source = 568, 0
+			}
+			tile
+			{
+				cell = 3, 2
+				source = 568, 0
+			}
+			tile
+			{
+				cell = 4, 2
+				source = 568, 0
+			}
+			tile
+			{
+				cell = 5, 2
+				source = 710, 142
+			}
+			tile
+			{
+				cell = 6, 2
+				source = 497, 284
+			}
+		}
+	}
+
+	node player
+	{
+		sprite
+		{
+			path = res/common/sprites/player1.png
+
+			width = 72
+			height = 97
+
+			source = 67, 196, 66, 92
+			frameCount = 13
+		}
+
+		// Position player at lower-left. Y position is floor's tileset height (tileHeight * rows)
+		translate = 0, 210, 0
+	}
+
+	node rocket
+	{
+		sprite
+		{
+			path = res/common/sprites/rocket.png
+
+			width = 128
+			height = 128
+
+			blendMode = BLEND_ADDITIVE
+			anchor = 0.5, 0.3
+			offset = OFFSET_ANCHOR
+		}
+
+		translate = 1280, 0, 0
+		rotate = 0, 0, 1, -45
+	}
+
+	node water
+	{
+		// Sprite drawable set in code because Effect isn't supported
+
+		translate = 0, -50, 0
+	}
+
+	node text
+	{
+		text
+		{
+			font = res/ui/arial.gpb
+
+			text = P1
+			size = 18
+			color = 0, 0, 1, 1
+		}
+	}
+
+	// Set active camera
+	activeCamera = camera
+}

--- a/samples/browser/sample-browser.vcxproj.filters
+++ b/samples/browser/sample-browser.vcxproj.filters
@@ -345,9 +345,6 @@
     <ClInclude Include="src\WaterSample.h">
       <Filter>src</Filter>
     </ClInclude>
-    <ClInclude Include="src\ParticlesSample.h" />
-    <ClInclude Include="src\FontSample.h" />
-    <ClInclude Include="src\SpriteSample.h" />
     <ClInclude Include="src\SceneCreateSample.h">
       <Filter>src</Filter>
     </ClInclude>
@@ -355,6 +352,15 @@
       <Filter>src</Filter>
     </ClInclude>
     <ClInclude Include="src\AudioSample.h">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="src\FontSample.h">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="src\ParticlesSample.h">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="src\SpriteSample.h">
       <Filter>src</Filter>
     </ClInclude>
   </ItemGroup>
@@ -419,9 +425,6 @@
     <ClCompile Include="src\WaterSample.cpp">
       <Filter>src</Filter>
     </ClCompile>
-    <ClCompile Include="src\ParticlesSample.cpp" />
-    <ClCompile Include="src\FontSample.cpp" />
-    <ClCompile Include="src\SpriteSample.cpp" />
     <ClCompile Include="src\SceneCreateSample.cpp">
       <Filter>src</Filter>
     </ClCompile>
@@ -429,6 +432,15 @@
       <Filter>src</Filter>
     </ClCompile>
     <ClCompile Include="src\AudioSample.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="src\FontSample.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="src\ParticlesSample.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="src\SpriteSample.cpp">
       <Filter>src</Filter>
     </ClCompile>
   </ItemGroup>

--- a/samples/browser/src/SpriteSample.cpp
+++ b/samples/browser/src/SpriteSample.cpp
@@ -7,12 +7,7 @@
 
 SpriteSample::SpriteSample()
     : _font(NULL), _scene(NULL), _cameraNode(NULL),
-      _floorTileSet(NULL), _floorNode(NULL),
-      _backgroundSprite(NULL), _backgroundNode(NULL),
-      _playerSprite(NULL), _playerNode(NULL), _playerAnimation(NULL), _playerMovement(0),
-      _rocketSprite(NULL), _rocketNode(NULL),
-      _waterSprite(NULL), _waterNode(NULL),
-      _text(NULL), _textNode(NULL)
+      _playerSprite(NULL), _playerNode(NULL), _playerAnimation(NULL), _playerMovement(0)
 {
 }
 
@@ -21,121 +16,70 @@ void SpriteSample::initialize()
     // Create the font for drawing the framerate.
     _font = Font::create("res/ui/arial.gpb");
 
-    // Create an orthographic projection matrix.
-    float width = (float)getWidth();
-    float height = (float)getHeight();
-    float aspectRatio = width / height;
-    _scene = Scene::create();
-    _cameraNode = _scene->addNode("camera");
-    Camera* camera = Camera::createOrthographic(width, height, aspectRatio, 0, 100);
-    _cameraNode->setCamera(camera);
-    _scene->setActiveCamera(camera);
-    SAFE_RELEASE(camera);
-    _cameraNode->translateX(width / 2);
-    _cameraNode->translateY(height / 2);
+	// Load sprite scene
+	_scene = Scene::load("res/common/sprites/sprite.scene");
+	_cameraNode = _scene->findNode("camera");
 
-    // Background sprite image
-    _backgroundSprite = Sprite::create("res/common/sprites/background.png", getWidth() * 5, getHeight());
-    _backgroundNode = _scene->addNode("background");
-    _backgroundNode->setDrawable(_backgroundSprite);
-    
-    // Level floor tile set
-    _floorTileSet = TileSet::create("res/common/sprites/level.png", 70, 70, 3, 7);
-    _floorTileSet->setTileSource(0, 0, Vector2(568, 284));
-    _floorTileSet->setTileSource(1, 0, Vector2(568, 284));
-    _floorTileSet->setTileSource(2, 0, Vector2(568, 284));
-    _floorTileSet->setTileSource(3, 0, Vector2(568, 284));
-    _floorTileSet->setTileSource(4, 0, Vector2(497, 284));
-    
-    _floorTileSet->setTileSource(0, 1, Vector2(568, 0));
-    _floorTileSet->setTileSource(1, 1, Vector2(568, 0));
-    _floorTileSet->setTileSource(2, 1, Vector2(568, 0));
-    _floorTileSet->setTileSource(3, 1, Vector2(568, 0));
-    _floorTileSet->setTileSource(4, 1, Vector2(710, 142));
-    _floorTileSet->setTileSource(5, 1, Vector2(497, 284));
-    
-    _floorTileSet->setTileSource(0, 2, Vector2(568, 0));
-    _floorTileSet->setTileSource(1, 2, Vector2(568, 0));
-    _floorTileSet->setTileSource(2, 2, Vector2(568, 0));
-    _floorTileSet->setTileSource(3, 2, Vector2(568, 0));
-    _floorTileSet->setTileSource(4, 2, Vector2(568, 0));
-    _floorTileSet->setTileSource(5, 2, Vector2(710, 142));
-    _floorTileSet->setTileSource(6, 2, Vector2(497, 284));
-    
-    _floorNode = _scene->addNode("floor");
-    _floorNode->setDrawable(_floorTileSet);
-    
-    // Idle[0]
-    _playerSprite = Sprite::create("res/common/sprites/player1.png", 72.0f, 97.0f, Rectangle(67, 196, 66, 92), 13);
-    //_playerSprite->computeFrames(3, 1);
-    // Walk [1 - 11]
-    _playerSprite->setFrameSource(1, Rectangle( 0, 0, 72, 92));
-    _playerSprite->setFrameSource(2, Rectangle(73, 0, 72, 97));
-    _playerSprite->setFrameSource(3, Rectangle(146, 0, 72, 97));
-    _playerSprite->setFrameSource(4, Rectangle(0, 98, 72, 97));
-    _playerSprite->setFrameSource(5, Rectangle(73, 98, 72, 97));
-    _playerSprite->setFrameSource(6, Rectangle(146, 98, 72, 97));
-    _playerSprite->setFrameSource(7, Rectangle(219, 0, 72, 97));
-    _playerSprite->setFrameSource(8, Rectangle(292, 0, 72, 97));
-    _playerSprite->setFrameSource(9, Rectangle(219, 98, 72, 97));
-    _playerSprite->setFrameSource(10, Rectangle(365, 0, 72, 97));
-    _playerSprite->setFrameSource(11, Rectangle(292, 98, 72, 97));
-    // Jump[12]
-    _playerSprite->setFrameSource(12, Rectangle(438, 93, 67, 94));
-    _playerNode = _scene->addNode("player");
-    _playerNode->setDrawable(_playerSprite);
-    _playerNode->translateY(_floorTileSet->getHeight());
-    
-    // The player animation clips
-    unsigned int keyTimes[4] = {0, 1, 11, 12};
-    float keyValues[4] =  { 0, 1, 11, 12 };
-    _playerAnimation = _playerSprite->createAnimation("player-animations", Sprite::ANIMATE_KEYFRAME, 4, keyTimes, keyValues,
-                                                Curve::LINEAR);
-    _playerAnimation->createClip("idle", 0, 0);
-    _playerAnimation->createClip("walk", 1, 11)->setRepeatCount(AnimationClip::REPEAT_INDEFINITE);
-    // Set the speed to 24 FPS
-    _playerAnimation->getClip("walk")->setSpeed(24.0f/1000.0f);
-    _playerAnimation->play("idle");
-    
-    // Rocket
-    _rocketSprite = Sprite::create("res/common/sprites/rocket.png", 128, 128);
-    _rocketSprite->setBlendMode(Sprite::BLEND_ADDITIVE);
-    _rocketSprite->setAnchor(Vector2(0.5f, 0.3f));
-    _rocketSprite->setOffset(Sprite::OFFSET_ANCHOR);
-    _rocketNode = _scene->addNode("rocket");
-    _rocketNode->setDrawable(_rocketSprite);
-    _rocketNode->translate(Vector3(getWidth(), 0,  0));
-    _rocketNode->rotateZ(MATH_DEG_TO_RAD(-45));
-    
-    // Custom Effect in sprite
-    Effect* waterEffect = Effect::createFromFile("res/shaders/sprite.vert", "res/common/sprites/water2d.frag");
-    _waterSprite = Sprite::create("res/common/sprites/water2d.png", getWidth() * 5, getHeight() / 3, waterEffect);
-    _waterSprite->setAnchor(Vector2::zero());
-    _waterSprite->setOpacity(0.5f);
-    _waterNode = _scene->addNode("water");
-    _waterNode->setDrawable(_waterSprite);
-    Material* waterMaterial = _waterSprite->getMaterial();
-    Texture::Sampler* noiseSampler = Texture::Sampler::create("res/common/sprites/water2d-noise.png");
-    waterMaterial->getParameter("u_texture_noise")->setValue(noiseSampler);
-    SAFE_RELEASE(noiseSampler);
-    waterMaterial->getParameter("u_time")->bindValue(this, &SpriteSample::getTime);
-    _waterNode->translateY(-50);
-    
-    // Text node.
-    _text = Text::create("res/ui/arial.gpb", "P1", Vector4(0, 0, 1, 1), 18);
-    _textNode = Node::create("text");
-    _playerNode->addChild(_textNode);
-    _text->setWidth(dynamic_cast<Sprite*>(_playerNode->getDrawable())->getWidth());
-    _textNode->setDrawable(_text);
-    _text->setJustify(Font::ALIGN_TOP_HCENTER);
-    _textNode->translateY(dynamic_cast<Sprite*>(_playerNode->getDrawable())->getHeight());
+	// Setup the player
+	_playerNode = _scene->findNode("player");
+	_playerSprite = dynamic_cast<Sprite*>(_playerNode->getDrawable());
+
+	// Idle [0] - Set at load time
+	// Walk [1 - 11]
+	_playerSprite->setFrameSource(1, Rectangle( 0, 0, 72, 92));
+	_playerSprite->setFrameSource(2, Rectangle(73, 0, 72, 97));
+	_playerSprite->setFrameSource(3, Rectangle(146, 0, 72, 97));
+	_playerSprite->setFrameSource(4, Rectangle(0, 98, 72, 97));
+	_playerSprite->setFrameSource(5, Rectangle(73, 98, 72, 97));
+	_playerSprite->setFrameSource(6, Rectangle(146, 98, 72, 97));
+	_playerSprite->setFrameSource(7, Rectangle(219, 0, 72, 97));
+	_playerSprite->setFrameSource(8, Rectangle(292, 0, 72, 97));
+	_playerSprite->setFrameSource(9, Rectangle(219, 98, 72, 97));
+	_playerSprite->setFrameSource(10, Rectangle(365, 0, 72, 97));
+	_playerSprite->setFrameSource(11, Rectangle(292, 98, 72, 97));
+	// Jump[12]
+	_playerSprite->setFrameSource(12, Rectangle(438, 93, 67, 94));
+
+	// The player animation clips
+	unsigned int keyTimes[4] = {0, 1, 11, 12};
+	float keyValues[4] =  { 0, 1, 11, 12 };
+	_playerAnimation = _playerSprite->createAnimation("player-animations", Sprite::ANIMATE_KEYFRAME, 4, keyTimes, keyValues, Curve::LINEAR);
+	_playerAnimation->createClip("idle", 0, 0);
+	_playerAnimation->createClip("walk", 1, 11)->setRepeatCount(AnimationClip::REPEAT_INDEFINITE);
+	// Set the speed to 24 FPS
+	_playerAnimation->getClip("walk")->setSpeed(24.0f/1000.0f);
+	_playerAnimation->play("idle");
+
+	// Setup player text
+	Node* playerTextNode = _scene->findNode("text");
+	playerTextNode->addRef();
+	_scene->removeNode(playerTextNode); //XXX This is because SceneLoader doesn't support loading child nodes for other nodes
+	_playerNode->addChild(playerTextNode);
+
+	playerTextNode->translateY(_playerSprite->getHeight());
+	Text* playerText = dynamic_cast<Text*>(playerTextNode->getDrawable());
+	playerText->setJustify(Font::ALIGN_TOP_HCENTER);
+	playerText->setWidth(_playerSprite->getWidth());
+	SAFE_RELEASE(playerTextNode);
+
+	// Custom Effect in sprite
+	Effect* waterEffect = Effect::createFromFile("res/shaders/sprite.vert", "res/common/sprites/water2d.frag");
+	Sprite* waterSprite = Sprite::create("res/common/sprites/water2d.png", getWidth() * 5, getHeight() / 3, waterEffect);
+	SAFE_RELEASE(waterEffect);
+	waterSprite->setAnchor(Vector2::zero());
+	waterSprite->setOpacity(0.5f);
+	_scene->findNode("water")->setDrawable(waterSprite);
+	Material* waterMaterial = waterSprite->getMaterial();
+	SAFE_RELEASE(waterSprite);
+	Texture::Sampler* noiseSampler = Texture::Sampler::create("res/common/sprites/water2d-noise.png");
+	waterMaterial->getParameter("u_texture_noise")->setValue(noiseSampler);
+	SAFE_RELEASE(noiseSampler);
+	waterMaterial->getParameter("u_time")->bindValue(this, &SpriteSample::getTime);
 }
 
 void SpriteSample::finalize()
 {
-    SAFE_RELEASE(_playerSprite);
-    SAFE_RELEASE(_rocketSprite);
-    SAFE_RELEASE(_waterSprite);
+	SAFE_RELEASE(_scene);
 }
 
 void SpriteSample::update(float elapsedTime)

--- a/samples/browser/src/SpriteSample.h
+++ b/samples/browser/src/SpriteSample.h
@@ -44,20 +44,10 @@ private:
     Font* _font;
     Scene* _scene;
     Node* _cameraNode;
-    TileSet* _floorTileSet;
-    Node* _floorNode;
-    Sprite* _backgroundSprite;
-    Node* _backgroundNode;
     Sprite* _playerSprite;
     Node* _playerNode;
     Animation* _playerAnimation;
     int _playerMovement;
-    Sprite* _rocketSprite;
-    Node* _rocketNode;
-    Sprite* _waterSprite;
-    Node* _waterNode;
-    Text* _text;
-    Node* _textNode;
     
 };
 


### PR DESCRIPTION
Fixed bug where loading tile sources for a TileSet would fail for any cell with a 0.
Made sure font, particle, and sprite samples were located in src folder.

Part of original ticket: #1650 