### PR TITLE
Properties bug: circular inheritence

### DIFF
--- a/gameplay/src/Properties.h
+++ b/gameplay/src/Properties.h
@@ -563,6 +563,7 @@ private:
     std::vector<Properties*>::const_iterator _namespacesItr;
     std::vector<Property>* _variables;
     std::string* _dirPath;
+    bool _visited;
     Properties* _parent;
 };
 


### PR DESCRIPTION
Simple fix to prevent circular references in Properties inheritance