### PR TITLE
correct comments that Material::create::defines is semicolon-separated 

### DIFF
--- a/gameplay/src/Effect.cpp
+++ b/gameplay/src/Effect.cpp
@@ -240,7 +240,7 @@ Effect* Effect::createFromSource(const char* vshPath, const char* vshSource, con
     GLint length;
     GLint success;
 
-    // Replace all comma separated definitions with #define prefix and \n suffix
+    // Replace all semicolon-separated definitions with #define prefix and \n suffix
     std::string definesStr = "";
     replaceDefines(defines, definesStr);
     

--- a/gameplay/src/Material.h
+++ b/gameplay/src/Material.h
@@ -97,7 +97,7 @@ public:
      *
      * @param vshPath Path to the vertex shader file.
      * @param fshPath Path to the fragment shader file.
-     * @param defines New-line delimited list of preprocessor defines.
+     * @param defines Semicolon delimited list of preprocessor defines.
      * 
      * @return A new Material.
      * @script{create}


### PR DESCRIPTION
The comments on the Material::create(..) API are misleading: defines is a semicolon-delimited string.
(This patch does not change any code, only updates comments to match the existing code)