### PR TITLE
Dynamic fontSize in UI Control

### DIFF
--- a/gameplay/src/Control.h
+++ b/gameplay/src/Control.h
@@ -674,8 +674,9 @@ public:
      * @param size The new font size.
      * @param states The states to set this property on.
      *               One or more members of the Control::State enum, ORed together.
+     * @param percentage The size is expressed as a percentage of the viewport height
      */
-    void setFontSize(unsigned int size, unsigned char states = STATE_ALL);
+    void setFontSize(unsigned int size, unsigned char states = STATE_ALL, bool percentage = false);
 
     /**
      * Get this control's font size for a given state.
@@ -1079,6 +1080,26 @@ protected:
     void setHeightInternal(float height, bool percentage = false);
 
     /**
+     * Internal method for setting the font size of the control.
+     *
+     * The font size of the control is set without modifying the existing AutoSize
+     * rules for the control.
+     *
+     * This method is meant for internal use by the Control or descendent classes
+     * who need to modify the size of the control during bounds computation.
+     *
+     * @see setFontSize(float, unsigned char, bool)
+     */
+    void setFontSizeInternal(unsigned int fontSize, unsigned char states, bool percentage);
+
+    /**
+     * Determines if the font size of this control is computed as a percentage of container height.
+     *
+     * @return True if the font size is computed as a percentage of container height.
+     */
+    bool isFontSizePercentage() const;
+
+    /**
      * Get the overlay type corresponding to this control's current state.
      *
      * @return The overlay type corresponding to this control's current state.
@@ -1369,7 +1390,7 @@ protected:
      * Local bounds, relative to parent container's clipping window, possibly stored as percentages (see _boundsBits).
      */
     Rectangle _relativeBounds;
-
+    
     /**
      * Local bounds, relative to parent container's clipping window, and desired size.
      */
@@ -1400,6 +1421,16 @@ protected:
      */
     Rectangle _viewportClipBounds;
 
+    /**
+     * If bits set, the font size is relative to bounds height for the corresponding State
+     */
+    unsigned char _relativeFontSizeStates;
+
+    /**
+     * Font size expressed as a percentage of bounds height (see _relativeFontSizeStates)
+     */
+    unsigned int _relativeFontSize;
+    
     /**
      * Control dirty bits.
      */

--- a/samples/browser/res/common/forms/formDynamic.form
+++ b/samples/browser/res/common/forms/formDynamic.form
@@ -1,0 +1,79 @@
+form dynamic
+{
+    layout = LAYOUT_VERTICAL
+    size = 600, 600
+
+	slider dynamicSizeSlider
+	{
+		width = 400
+		orientation = HORIZONTAL
+		min = 300
+		max = 1000
+		value = 400
+		//step = 5
+		text = Size of the container below
+		valueTextVisible = true
+	}
+
+    container dynamicContainer
+    {
+        style = panel
+        width = 400
+        height = 400
+
+        scroll = SCROLL_BOTH
+        scrollBarsAutoHide = true
+
+        layout = LAYOUT_VERTICAL
+
+
+        textBox testTextBox
+        {
+            size = 100%, 22%
+            fontSize = 25%
+            text = This demonstrates how expressing object bounds and font sizes as percentages can enable GamePlay's UI system to create interfaces which scale with the device's screen size.
+        }
+
+        radioButton form0
+        {
+            text = The size (or height, and/or width) of
+
+            group = formSelection
+            selected = true
+
+            height = 8.5%
+            fontSize = 47%
+        }
+
+        radioButton form1 : form0
+        {
+            text = any container or control can be expressed
+            selected = false
+        }
+
+        radioButton form2 : form1
+        {
+            text = as a percentage of its parent view.
+        }
+
+        CheckBox
+        {
+            height = 8.5%
+            fontSize = 47%
+
+            text = This fontSize is 47% of the height of its container
+        }
+
+        Button
+        {
+            text = That's Cool
+            fontSize = 100%
+
+            height = 15%
+            autoSize AUTO_SIZE_WIDTH
+
+            alignment = ALIGN_RIGHT
+        }
+
+    }
+}

--- a/samples/browser/res/common/forms/formSelect.form
+++ b/samples/browser/res/common/forms/formSelect.form
@@ -35,6 +35,12 @@ form formSelect
 
 	radioButton form5 : form1
 	{
+		text = Dynamic
+	}
+
+	radioButton form6 : form1
+	{
 		text = Programmatic
 	}
+
 }

--- a/samples/browser/src/FormsSample.cpp
+++ b/samples/browser/src/FormsSample.cpp
@@ -7,7 +7,7 @@
 // Input bit-flags
 #define KEY_BACK 1
 
-const static unsigned int __formsCount = 5;
+const static unsigned int __formsCount = 6;
 
 FormsSample::FormsSample()
     : _scene(NULL), _formNode(NULL), _formNodeParent(NULL), _formSelect(NULL), _activeForm(NULL), _gamepad(NULL), _keyFlags(0)
@@ -19,6 +19,7 @@ FormsSample::FormsSample()
         "res/common/forms/formFlowLayout.form",
         "res/common/forms/formVerticalLayout.form",
         "res/common/forms/formZOrder.form",
+        "res/common/forms/formDynamic.form",
     };
 
     _formFiles.assign(formFiles, formFiles + __formsCount);
@@ -93,6 +94,10 @@ void FormsSample::initialize()
     
     RadioButton* form5Button = static_cast<RadioButton*>(_formSelect->getControl("form5"));
     form5Button->addListener(this, Control::Listener::CLICK);
+
+    RadioButton* form6Button = static_cast<RadioButton*>(_formSelect->getControl("form6"));
+    form6Button->addListener(this, Control::Listener::CLICK);
+
     for (unsigned int i = 0; i < _formFiles.size(); i++)
     {
 		Form* form = Form::create(_formFiles[i]);
@@ -100,6 +105,11 @@ void FormsSample::initialize()
         _forms.push_back(form);
     }
     _formIndex = 0;
+    
+    
+    Slider* dynamicSizeSlider = static_cast<Slider*>(_forms[5]->getControl("dynamicSizeSlider"));
+    dynamicSizeSlider->addListener(this, Control::Listener::VALUE_CHANGED);
+
 
     // Create a form programmatically.
     createSampleForm();
@@ -328,11 +338,26 @@ void FormsSample::controlEvent(Control* control, EventType evt)
             _formIndex = 5;
             formChanged();
         }
+        else if (strcmp("form6", control->getId()) == 0)
+        {
+            _formIndex = 6;
+            formChanged();
+        }
         else if (strcmp("opacityButton", control->getId()) == 0)
         {
             float from[] = { 1.0f };
             float to[] = { 0.5f };
             control->createAnimationFromTo("opacityButton", Form::ANIMATE_OPACITY, from, to, Curve::LINEAR, 1000)->getClip()->play();
+        }
+    }
+    else if (evt == VALUE_CHANGED)
+    {
+        if (strcmp("dynamicSizeSlider", control->getId()) == 0)
+        {
+            Slider* dynamicSizeSlider = static_cast<Slider*>(control);
+            float size = dynamicSizeSlider->getValue();
+        
+            control->getTopLevelForm()->getControl("dynamicContainer")->setSize(size, size);
         }
     }
 }


### PR DESCRIPTION
Adds support for a UI Control's fontSize to be expressed as a percentage of the height of the view containing it.

Add a form to the Forms sample code which demonstrates use of the feature.


This version of the code contains a couple of known issues, but in the meantime I'd be interested in feedback of whether you approve of the concept and general form of this feature.

1. This is incompatible with autoSize = AUTOSIZE_HEIGHT due to the circular dependency of what height the control should be, but the case is not detected (either to generate an explicit warning, or choose a sensible default size)
2. Theoretically a style could have different percentages for different values of State - this code will not currently cope with that case.