### PR TITLE
autoSize issue in nested containers

### DIFF
--- a/gameplay/src/Container.cpp
+++ b/gameplay/src/Container.cpp
@@ -554,9 +554,11 @@ void Container::updateBounds()
             for (size_t i = 0, count = _controls.size(); i < count; ++i)
             {
                 Control* ctrl = _controls[i];
-                if (ctrl->isVisible() && !ctrl->isXPercentage() && !ctrl->isWidthPercentage())
+                if (ctrl->isVisible() && !ctrl->isWidthPercentage())
                 {
-                    float w = ctrl->getX() + ctrl->getWidth();
+                    float w = ctrl->getWidth();
+                    if (!ctrl->isXPercentage())
+                        w += ctrl->getX();
                     if (width < w)
                         width = w;
                 }
@@ -572,9 +574,11 @@ void Container::updateBounds()
             for (size_t i = 0, count = _controls.size(); i < count; ++i)
             {
                 Control* ctrl = _controls[i];
-                if (ctrl->isVisible() && !ctrl->isYPercentage() && !ctrl->isHeightPercentage())
+                if (ctrl->isVisible() && !ctrl->isHeightPercentage())
                 {
-                    float h = ctrl->getY() + ctrl->getHeight();
+                    float h = ctrl->getHeight();
+                    if (!ctrl->isYPercentage())
+                        h += ctrl->getY();
                     if (height < h)
                         height = h;
                 }


### PR DESCRIPTION
The width of a container must contribute to the width of its parent, even if its position does not