### PR TITLE
Fix for not releasing audio device on Android

### DIFF
--- a/gameplay/src/AudioController.cpp
+++ b/gameplay/src/AudioController.cpp
@@ -81,11 +81,17 @@ void AudioController::pause()
         _pausingSource = NULL;
         itr++;
     }
+#ifdef ALC_SOFT_pause_device
+    alcDevicePauseSOFT(_alcDevice);
+#endif
 }
 
 void AudioController::resume()
 {   
     alcMakeContextCurrent(_alcContext);
+#ifdef ALC_SOFT_pause_device
+    alcDeviceResumeSOFT(_alcDevice);
+#endif
 
     std::set<AudioSource*>::iterator itr = _playingSources.begin();
 

--- a/gameplay/src/Base.h
+++ b/gameplay/src/Base.h
@@ -182,6 +182,8 @@ extern int strcmpnocase(const char* s1, const char* s2);
 #ifdef __ANDROID__
     #include <AL/al.h>
     #include <AL/alc.h>
+    #define AL_ALEXT_PROTOTYPES
+    #include <AL/alext.h>
 #elif WIN32
     #define AL_LIBTYPE_STATIC
     #include <AL/al.h>


### PR DESCRIPTION
OpenAL soft has the pause/resume extensions on Android. So, these are
used when going to and coming back from background.

Fixes #1649