### PR TITLE
Float depth

### DIFF
--- a/gameplay/src/FrameBuffer.cpp
+++ b/gameplay/src/FrameBuffer.cpp
@@ -203,7 +203,7 @@ void FrameBuffer::setRenderTarget(RenderTarget* target, unsigned int index, GLen
 #ifndef OPENGL_ES            
             glDrawBuffer(GL_NONE);
             glReadBuffer(GL_NONE);
-#else
+#elif defined(GL_ES_VERSION_3_0) && GL_ES_VERSION_3_0
             glDrawBuffers(0, NULL);
 #endif
         }

--- a/gameplay/src/FrameBuffer.cpp
+++ b/gameplay/src/FrameBuffer.cpp
@@ -198,15 +198,19 @@ void FrameBuffer::setRenderTarget(RenderTarget* target, unsigned int index, GLen
         GLenum attachment;
         if (target->getTexture()->getFormat() == Texture::DEPTH)
         {
-        	attachment = GL_DEPTH_ATTACHMENT;
-        	GL_ASSERT( glFramebufferTexture2D(GL_FRAMEBUFFER, attachment, textureTarget, _renderTargets[index]->getTexture()->getHandle(), 0));
-        	glDrawBuffer(GL_NONE);
-        	glReadBuffer(GL_NONE);
+            attachment = GL_DEPTH_ATTACHMENT;
+            GL_ASSERT( glFramebufferTexture2D(GL_FRAMEBUFFER, attachment, textureTarget, _renderTargets[index]->getTexture()->getHandle(), 0));
+#ifndef OPENGL_ES            
+            glDrawBuffer(GL_NONE);
+            glReadBuffer(GL_NONE);
+#else
+            glDrawBuffers(0, NULL);
+#endif
         }
         else
         {
             attachment = GL_COLOR_ATTACHMENT0 + index;
-        	GL_ASSERT( glFramebufferTexture2D(GL_FRAMEBUFFER, attachment, textureTarget, _renderTargets[index]->getTexture()->getHandle(), 0) );
+            GL_ASSERT( glFramebufferTexture2D(GL_FRAMEBUFFER, attachment, textureTarget, _renderTargets[index]->getTexture()->getHandle(), 0) );
         }
 
         GLenum fboStatus = glCheckFramebufferStatus(GL_FRAMEBUFFER);

--- a/gameplay/src/Texture.cpp
+++ b/gameplay/src/Texture.cpp
@@ -185,7 +185,11 @@ Texture* Texture::create(Format format, unsigned int width, unsigned int height,
         // Texture 2D
         if (format == Texture::DEPTH)
         {
+#if !defined(OPENGL_ES) || defined(GL_ES_VERSION_3_0) && GL_ES_VERSION_3_0
     		GL_ASSERT( glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT32F, width, height, 0, GL_DEPTH_COMPONENT, GL_FLOAT, data) );
+#else
+    		GL_ASSERT( glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, width, height, 0, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, data) );
+#endif    		
         }
         else
         {
@@ -232,7 +236,9 @@ Texture* Texture::create(Format format, unsigned int width, unsigned int height,
     	GL_ASSERT( glTexParameteri(target, GL_TEXTURE_MIN_FILTER, GL_NEAREST) );
     	GL_ASSERT( glTexParameteri(target, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE) );
     	GL_ASSERT( glTexParameteri(target, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE) );
+#if !defined(OPENGL_ES) || defined(GL_ES_VERSION_3_0) && GL_ES_VERSION_3_0
     	GL_ASSERT( glTexParameteri(target, GL_TEXTURE_COMPARE_MODE, GL_NONE) );
+#endif    	
     }
     else
     {


### PR DESCRIPTION
Fixed to compile for OpenGL ES 2.0 (and still work, albeit at a performance hit -- would not recommend using this feature on mobile).  Defines included so it will work properly if using OpenGL ES 3.0.

