### PR TITLE
Texture packer feature for the encoder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,6 @@ gameplay.xcworkspace/xcshareddata/gameplay.xccheckout
 /gameplay/gameplay.xcodeproj/xcuserdata
 /gameplay/gameplay.vcxproj.user
 
-/tools/encoder
 /tools/encoder/Debug
 /tools/encoder/Release
 /tools/encoder/gameplay-encoder.xcodeproj/xcuserdata

--- a/tools/encoder/CMakeLists.txt
+++ b/tools/encoder/CMakeLists.txt
@@ -111,6 +111,8 @@ set(APP_SRC
     src/Scene.h
     src/StringUtil.cpp
     src/StringUtil.h
+    src/TexturePacker.h
+    src/TexturePacker.cpp
     src/Thread.h
     src/Transform.cpp
     src/Transform.h

--- a/tools/encoder/gameplay-encoder.xcodeproj/project.pbxproj
+++ b/tools/encoder/gameplay-encoder.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		B661734316A61CFA0083A307 /* NormalMapGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B661734116A61CFA0083A307 /* NormalMapGenerator.cpp */; };
 		C0575FA21B4C5C3A007B96B0 /* TMXSceneEncoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C0575F9E1B4C5C3A007B96B0 /* TMXSceneEncoder.cpp */; };
 		C0575FA31B4C5C3A007B96B0 /* TMXTypes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C0575FA01B4C5C3A007B96B0 /* TMXTypes.cpp */; };
+		C0575FA61B4C6C15007B96B0 /* TexturePacker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C0575FA41B4C6C14007B96B0 /* TexturePacker.cpp */; };
 		C076C905174F6D2E00645678 /* Constants.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C076C8FF174F6D2E00645678 /* Constants.cpp */; };
 		C076C906174F6D2E00645678 /* FBXUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C076C901174F6D2E00645678 /* FBXUtil.cpp */; };
 		C076C907174F6D2E00645678 /* Sampler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C076C903174F6D2E00645678 /* Sampler.cpp */; };
@@ -183,6 +184,8 @@
 		C0575F9F1B4C5C3A007B96B0 /* TMXSceneEncoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TMXSceneEncoder.h; path = src/TMXSceneEncoder.h; sourceTree = SOURCE_ROOT; };
 		C0575FA01B4C5C3A007B96B0 /* TMXTypes.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TMXTypes.cpp; path = src/TMXTypes.cpp; sourceTree = SOURCE_ROOT; };
 		C0575FA11B4C5C3A007B96B0 /* TMXTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TMXTypes.h; path = src/TMXTypes.h; sourceTree = SOURCE_ROOT; };
+		C0575FA41B4C6C14007B96B0 /* TexturePacker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TexturePacker.cpp; path = src/TexturePacker.cpp; sourceTree = SOURCE_ROOT; };
+		C0575FA51B4C6C14007B96B0 /* TexturePacker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TexturePacker.h; path = src/TexturePacker.h; sourceTree = SOURCE_ROOT; };
 		C076C8FF174F6D2E00645678 /* Constants.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Constants.cpp; path = src/Constants.cpp; sourceTree = SOURCE_ROOT; };
 		C076C900174F6D2E00645678 /* Constants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Constants.h; path = src/Constants.h; sourceTree = SOURCE_ROOT; };
 		C076C901174F6D2E00645678 /* FBXUtil.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FBXUtil.cpp; path = src/FBXUtil.cpp; sourceTree = SOURCE_ROOT; };
@@ -326,6 +329,8 @@
 				42C8EDF914724CD700E43619 /* Scene.h */,
 				42C8EDFA14724CD700E43619 /* StringUtil.cpp */,
 				42C8EDFB14724CD700E43619 /* StringUtil.h */,
+				C0575FA41B4C6C14007B96B0 /* TexturePacker.cpp */,
+				C0575FA51B4C6C14007B96B0 /* TexturePacker.h */,
 				42C8EDFC14724CD700E43619 /* Transform.cpp */,
 				42C8EDFD14724CD700E43619 /* Transform.h */,
 				42C8EDFE14724CD700E43619 /* TTFFontEncoder.cpp */,
@@ -440,6 +445,7 @@
 				42C8EE2414724CD700E43619 /* MeshSubSet.cpp in Sources */,
 				42C8EE2514724CD700E43619 /* Model.cpp in Sources */,
 				42C8EE2614724CD700E43619 /* Node.cpp in Sources */,
+				C0575FA61B4C6C15007B96B0 /* TexturePacker.cpp in Sources */,
 				42C8EE2714724CD700E43619 /* Object.cpp in Sources */,
 				42C8EE2814724CD700E43619 /* Quaternion.cpp in Sources */,
 				42C8EE2914724CD700E43619 /* Reference.cpp in Sources */,

--- a/tools/encoder/src/EncoderArguments.cpp
+++ b/tools/encoder/src/EncoderArguments.cpp
@@ -29,7 +29,8 @@ EncoderArguments::EncoderArguments(size_t argc, const char** argv) :
     _optimizeAnimations(false),
     _animationGrouping(ANIMATIONGROUP_PROMPT),
     _outputMaterial(false),
-    _generateTextureGutter(false)
+    _generateTextureGutter(false),
+    _texturePacking(false)
 {
     __instance = this;
 
@@ -216,6 +217,16 @@ const Vector3& EncoderArguments::getHeightmapWorldSize() const
     return _heightmapWorldSize;
 }
 
+bool EncoderArguments::getTexturePacking() const
+{
+    return _texturePacking;
+}
+
+const std::string& EncoderArguments::getTexturePackerInput() const
+{
+    return _texturePackerInput;
+}
+
 bool EncoderArguments::parseErrorOccured() const
 {
     return _parseError;
@@ -271,6 +282,8 @@ void EncoderArguments::printUsage() const
     "  -m\t\tOutput material file for scene.\n" \
     "  -tb <node id>\n" \
         "\t\tGenerates tangents and binormals for the given node.\n" \
+    "  -tp <input file>\n" \
+        "\t\tGenerates texture atlas from given textures and adjusts the UV coordinates for meshes.\n" \
     "  -oa\n" \
         "\t\tOptimizes animations by analyzing animation channel data and\n" \
         "\t\tremoving any channels that contain default/identity values\n" \
@@ -680,6 +693,18 @@ void EncoderArguments::readOption(const std::vector<std::string>& options, size_
             {
                 _tangentBinormalId.insert(nodeId);
             }
+        }
+        else if (str.compare("-tp") == 0)
+        {
+            if ((*index + 1) >= options.size())
+            {
+                LOG(1, "Error: texture packer requires input file.\n");
+                _parseError = true;
+                return;
+            }
+            (*index)++;
+            _texturePackerInput = options[*index];
+            _texturePacking = true;
         }
         else if (str.compare("-textureGutter:none") == 0 || str.compare("-tg:none") == 0)
         {

--- a/tools/encoder/src/EncoderArguments.h
+++ b/tools/encoder/src/EncoderArguments.h
@@ -146,6 +146,16 @@ public:
      * This option is only applicable for normal map generation.
      */
     const Vector3& getHeightmapWorldSize() const;
+
+    /**
+     * Returns true if texture packing is enabled
+     */
+    bool getTexturePacking() const;
+
+    /**
+     * Returns the input file for texture packer
+     */
+    const std::string& getTexturePackerInput() const;
     
     /**
      * Returns true if an error occurred while parsing the command line arguments.
@@ -230,6 +240,9 @@ private:
     std::vector<std::string> _groupAnimationAnimationId;
     std::vector<HeightmapOption> _heightmaps;
     std::set<std::string> _tangentBinormalId;
+
+    std::string _texturePackerInput;
+    bool _texturePacking;
 
 };
 

--- a/tools/encoder/src/FBXSceneEncoder.cpp
+++ b/tools/encoder/src/FBXSceneEncoder.cpp
@@ -5,6 +5,7 @@
 #include "FBXSceneEncoder.h"
 #include "FBXUtil.h"
 #include "Sampler.h"
+#include "TexturePacker.h"
 
 using namespace gameplay;
 using std::string;
@@ -72,6 +73,21 @@ void FBXSceneEncoder::write(const string& filepath, const EncoderArguments& argu
     if (_autoGroupAnimations)
     {
         _gamePlayFile.groupMeshSkinAnimations();
+    }
+
+    if (arguments.getTexturePacking())
+    {
+        TexturePacker tp(&_gamePlayFile);
+        LOG(1, "Packing textures and adjusting texture coordinates from: %s\n",
+            arguments.getTexturePackerInput().c_str());
+        if (tp.parse(arguments.getTexturePackerInput()))
+        {
+            LOG(1, "Texture packing successful, writing result.\n");
+            tp.write();
+        } else
+        {
+            LOG(1, "Skipping texture packing.\n");
+        };
     }
     
     string outputFilePath = arguments.getOutputFilePath();

--- a/tools/encoder/src/Image.cpp
+++ b/tools/encoder/src/Image.cpp
@@ -163,6 +163,26 @@ void Image::setData(void* data)
     memcpy(_data, data, _width * _height * _bpp);
 }
 
+bool Image::paste(const Image *image, int x, int y)
+{
+    if (image->getFormat() != _format) {
+        LOG(1, "Formats don't match.\n");
+        return false;
+    }
+    if (_width < x + image->_width ||
+        _height < y + image->_height) {
+        LOG(1, "Image doesn't fit.\n");
+        return false;
+    }
+
+    int stride = _width * _bpp;
+    int lineSize = image->_width * _bpp;
+    for (int i = 0; i < image->_height; ++i) {
+        memcpy(_data + stride*(i+y) + x*_bpp, image->_data + lineSize*i, lineSize);
+    }
+    return true;
+}
+
 Image::Format Image::getFormat() const
 {
     return _format;

--- a/tools/encoder/src/Image.h
+++ b/tools/encoder/src/Image.h
@@ -60,6 +60,17 @@ public:
     void setData(void* data);
 
     /**
+     * Draws the given image inside this one.
+     * Must match pixel format and fit inside with the given offset.
+     * 
+     * @param image Image to paste inside this image
+     * @param x X-offset
+     * @param y Y-offset
+     * @return true on sucess
+     */
+    bool paste(const Image *image, int x, int y);
+
+    /**
      * Gets the image's format.
      * 
      * @return The image's format.

--- a/tools/encoder/src/TexturePacker.cpp
+++ b/tools/encoder/src/TexturePacker.cpp
@@ -450,7 +450,7 @@ void TexturePacker::updateUV(gameplay::TexturePacker::UVMapInfo uvmapinfo)
         v.texCoord[index].x = x;
 
         float y = v.texCoord[index].y;
-        y = oY + y*(1.0f - rY);
+        y = oY + y*rY;
         v.texCoord[index].y = y;
     }
 }

--- a/tools/encoder/src/TexturePacker.cpp
+++ b/tools/encoder/src/TexturePacker.cpp
@@ -404,13 +404,14 @@ bool TexturePacker::parse(string fileName)
         {
             LOG(1, "Failed to pack image: %s\n",
                 ai.ifile->getFileName().c_str());
+            delete ai.ifile;
             failed = true;
         }
 
         LOG(1, "\tPacked %s!\n", ai.ifile->getFileName().c_str());
     }
 
-    return true;
+    return !failed;
 }
 
 bool TexturePacker::write()

--- a/tools/encoder/src/TexturePacker.cpp
+++ b/tools/encoder/src/TexturePacker.cpp
@@ -1,0 +1,436 @@
+/*
+ Texture packer for creating a texture atlas from multiple textures and 
+ automatically updating UV coordinates for the meshes.
+ 
+ Atlas description format goes like:
+ 
+ #comments begin with hash sign
+ #textureAtlas outputFile sizeX, sizeY
+ textureAtlas diffuse.png, 1024, 1024
+     texture item1.png #texture inputFile
+     texture item2.png
+     texture item3.png
+
+ textureAtlas normal.png, 1024, 1024
+     texture itemN1.png
+     texture itemN2.png
+     texture itemN3.png
+
+ #node idInGPBFile
+ node item1
+	 uvmap 0, diffuse.png, item1.png #uvmap texCoordIndex, outputFile, inputFile
+	 uvmap 1, normal.png, itemN1.png
+ node item2
+     uvmap 0, diffuse.png, item1.png
+     uvmap 1, normal.png, itemN2.png
+ */
+
+#include "TexturePacker.h"
+
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <vector>
+#include <algorithm>
+#include <cctype>
+
+#include "Base.h"
+#include "Image.h"
+#include "GPBFile.h"
+
+using namespace std;
+
+namespace gameplay {
+
+class ImageFile {
+public:
+    static ImageFile* create(const string& fileName)
+    {
+        const Image *image = Image::create(fileName.c_str());
+        if (image) {
+            ImageFile *imageFile = new ImageFile(image, fileName);
+            return imageFile;
+        }
+
+        return NULL;
+    }
+
+    ~ImageFile()
+    {
+        if (_image)
+            delete _image;
+    }
+
+    const string& getFileName() const
+    {
+        return _fileName;
+    }
+
+    int getX() const { return _x; }
+    int getY() const { return _y; }
+    int getWidth() { return _width; }
+    int getHeight() { return _height; }
+    void setX(int x) { _x = x; }
+    void setY(int y) { _y = y; }
+    const Image* getImage() const { return _image; };
+private:
+    ImageFile(const Image *image, const string& fileName)
+    : _image(image), _fileName(fileName)
+    {
+        _width = _image->getWidth();
+        _height = _image->getHeight();
+    }
+
+    const Image *_image;
+    const string _fileName;
+    int _x, _y, _width, _height;
+};
+
+class TextureAtlas
+{
+public:
+    TextureAtlas(int width, int height)
+    : TextureAtlas(0, 0, width, height)
+    {
+    }
+
+    TextureAtlas(int x, int y, int w, int h)
+    : _x(x), _y(y), _width(w), _height(h), _sub1(NULL), _sub2(NULL),
+    _imageFile(NULL) {}
+
+    ~TextureAtlas()
+    {
+        if (_sub1)
+            delete _sub1;
+        if (_sub2)
+            delete _sub2;
+        if (_imageFile)
+            delete _imageFile;
+    }
+
+    bool pack(ImageFile *imageFile)
+    {
+        if (!_imageFile) {
+            if ((imageFile->getWidth() > _width) ||
+                (imageFile->getHeight() > _height)) {
+                return false;
+            }
+
+            _imageFile = imageFile;
+            _imageFile->setX(_x);
+            _imageFile->setY(_y);
+
+            _sub1 = new TextureAtlas(_x, _y + _imageFile->getHeight(),
+                                   imageFile->getWidth(),
+                                   _height - _imageFile->getHeight());
+            _sub2 = new TextureAtlas(_x + imageFile->getWidth(), _y,
+                                   _width - imageFile->getWidth(), _height);
+
+            return true;
+        }
+
+        return _sub1->pack(imageFile) || _sub2->pack(imageFile);
+    }
+
+    void write(const string& fileName)
+    {
+        if (!_imageFile)
+            return;
+        Image *image = Image::create(_imageFile->getImage()->getFormat(),
+                                     getWidth(), getHeight());
+        pasteImages(image);
+        image->save(fileName.c_str());
+        delete image;
+    }
+
+    void pasteImages(Image *image)
+    {
+        const ImageFile *i = _imageFile;
+        if (_imageFile)
+            image->paste(i->getImage(), i->getX(), i->getY());
+        if (_sub1)
+            _sub1->pasteImages(image);
+        if (_sub2)
+            _sub2->pasteImages(image);
+    }
+
+    int getX() const { return _x; }
+    int getY() const { return _y; }
+    int getWidth() const { return _width; }
+    int getHeight() const { return _height; }
+
+    const ImageFile* getImageFile() const { return _imageFile; }
+    const ImageFile* findImageFile(const string& name) const
+    {
+        if (!_imageFile)
+            return NULL;
+
+        if (_imageFile->getFileName() == name)
+            return _imageFile;
+
+        const ImageFile *i1 = _sub1->findImageFile(name),
+        *i2 = _sub2->findImageFile(name);
+        if (i1)
+            return i1;
+        return i2;
+    }
+private:
+    TextureAtlas *_sub1, *_sub2;
+    ImageFile *_imageFile;
+    const int _x, _y, _width, _height;
+};
+
+// trim from start
+static inline string &ltrim(string &s) {
+    s.erase(s.begin(), find_if(s.begin(), s.end(), not1(ptr_fun<int, int>(isspace))));
+    return s;
+}
+
+// trim from end
+static inline string &rtrim(string &s) {
+    s.erase(find_if(s.rbegin(), s.rend(), not1(ptr_fun<int, int>(isspace))).base(), s.end());
+    return s;
+}
+
+// trim comments
+static inline string &ctrim(string &s) {
+    size_t hashpos = s.find_first_of("#");
+    if (hashpos != string::npos)
+        s.erase(s.begin() + hashpos, s.end());
+    return s;
+}
+
+// trim from both ends and after comments
+static inline string &trim(string &s) {
+    return ltrim(rtrim(ctrim(s)));
+}
+
+TexturePacker::~TexturePacker()
+{
+    for (pair<string, TextureAtlas*> p: _atlases) {
+        delete p.second;
+    }
+}
+
+bool TexturePacker::parseLine(string& str, Line& line)
+{
+    string::iterator cursor = find_if(str.begin(), str.end(),
+                                      ptr_fun<int, int>(isspace));
+    string typestr = str.substr(0, cursor - str.begin());
+    string params = str.substr(cursor - str.begin(), string::npos);
+
+    if (typestr == "textureAtlas")
+        line.type = LineType::TextureAtlas;
+    else if (typestr == "texture")
+        line.type = LineType::Texture;
+    else if (typestr == "node")
+        line.type = LineType::Node;
+    else if (typestr == "uvmap")
+        line.type = LineType::UVMap;
+    else
+        return false;
+
+    stringstream p(params);
+    string t;
+    int i = 0;
+    while (getline(p, t, ',')) {
+        t = trim(t);
+        line.sparams[i++] = t;
+    }
+    line.paramsCount = i;
+
+    return true;
+}
+
+bool TexturePacker::parse(string fileName)
+{
+    ifstream infile(fileName);
+    if (!infile.is_open())
+    {
+        LOG(1, "Cannot open file: %s\n", fileName.c_str());
+        return false;
+    }
+
+    TextureAtlas *currentAtlas = NULL;
+    string currentNode = "";
+    string originalLine;
+    for (; getline(infile, originalLine);) {
+        string line = trim(originalLine);
+        Line l;
+
+        if (!(line.length() > 0))
+            continue;
+
+        if (!parseLine(line, l))
+            return false;
+
+        switch (l.type) {
+            case LineType::TextureAtlas:
+            {
+                currentNode = "";
+                if (l.paramsCount < 3)
+                {
+                    LOG(1, "textureAtlas too few parameters, %d instead of 3: ",
+                        l.paramsCount);
+                    LOG(1, "\"%s\"\n", originalLine.c_str());
+                    return false;
+                }
+                stringstream wi(l.sparams[1]), hi(l.sparams[2]);
+                int w, h;
+                wi >> w, hi >> h;
+
+                if (w <= 0 || h <= 0)
+                {
+                    LOG(1, "invalid textureAtlas size.\n");
+                    return false;
+                }
+
+                TextureAtlas *ta = new TextureAtlas(w, h);
+                _atlases[l.sparams[0]] = ta;
+                currentAtlas = ta;
+
+                break;
+            }
+            case LineType::Texture:
+            {
+                if (!currentAtlas)
+                {
+                    LOG(1, "Invalid texture item...\n");
+                    return false;
+                }
+                if (l.paramsCount < 1)
+                {
+                    LOG(1, "texture requires 1 parameter.\n");
+                    return false;
+                }
+                ImageFile *ifile = ImageFile::create(l.sparams[0]);
+                if (!ifile)
+                {
+                    LOG(1, "Cannot open image file - %s\n",
+                        ifile->getFileName().c_str());
+                    return false;
+                }
+                if (!currentAtlas->pack(ifile))
+                {
+                    LOG(1, "Could not pack image file - %s\n",
+                        ifile->getFileName().c_str());
+                    delete ifile;
+                    return false;
+                }
+                break;
+            }
+            case LineType::Node:
+            {
+                currentAtlas = NULL;
+                if (l.paramsCount < 1)
+                {
+                    LOG(1, "node requires 1 parameter.\n");
+                    return false;
+                }
+
+                Mesh *mesh = dynamic_cast<Mesh*>(
+                    _gpbFile->getFromRefTable(l.sparams[0] + meshSuffix));
+                if (!mesh)
+                {
+                    LOG(1, "Node %s doesn't exit or doesn't have a mesh.\n",
+                        l.sparams[0].c_str());
+                    return false;
+                }
+
+                currentNode = l.sparams[0];
+                break;
+            }
+            case LineType::UVMap:
+            {
+                if (currentNode.length() == 0)
+                {
+                    LOG(1, "Invalid uvmap item.\n");
+                    return false;
+                }
+                if (l.paramsCount < 3)
+                {
+                    LOG(1, "uvmap requires 3 parameters.\n");
+                    return false;
+                }
+                stringstream ii(l.sparams[0]);
+                int index;
+                ii >> index;
+                const string& textureAtlas = l.sparams[1];
+                const string& textureFile = l.sparams[2];
+
+                AtlasMap::iterator atlasIter = _atlases.find(textureAtlas);
+                if (atlasIter == _atlases.end())
+                {
+                    LOG(1, "TextureAtlas %s isn't defined.\n",
+                        textureAtlas.c_str());
+                    return false;
+                }
+
+                TextureAtlas *atlas = (*atlasIter).second;
+
+                const ImageFile *ifile = atlas->findImageFile(textureFile);
+                if (!ifile)
+                {
+                    LOG(1, "TextureAtlas %s doesn't have %s.\n",
+                        textureAtlas.c_str(), textureFile.c_str());
+                    return false;
+                }
+
+                struct UVMapInfo uvmapinfo = {
+                    .nodeId = currentNode,
+                    .texCoordIndex = index,
+                    .textureAtlasName = textureAtlas,
+                    .textureName = textureFile
+                };
+                _uvmaps.push_back(uvmapinfo);
+
+                break;
+            }
+        }
+    }
+
+    return true;
+}
+
+bool TexturePacker::write()
+{
+    for (pair<string, TextureAtlas*> p: _atlases)
+    {
+        p.second->write(p.first);
+    }
+
+    for (UVMapInfo uvmapinfo: _uvmaps) {
+        updateUV(uvmapinfo);
+    }
+    return true;
+}
+
+void TexturePacker::updateUV(gameplay::TexturePacker::UVMapInfo uvmapinfo)
+{
+    Mesh *mesh = dynamic_cast<Mesh*>(_gpbFile->getFromRefTable(uvmapinfo.nodeId + meshSuffix));
+    const TextureAtlas *atlas = (*_atlases.find(uvmapinfo.textureAtlasName)).second;
+    const ImageFile *ifile = atlas->findImageFile(uvmapinfo.textureName);
+    const int atlasWidth = atlas->getWidth(),
+              atlasHeight = atlas->getHeight(),
+              imageWidth = ifile->getImage()->getWidth(),
+              imageHeight = ifile->getImage()->getHeight(),
+              index = uvmapinfo.texCoordIndex;
+
+    const float rX = (float) imageWidth / (float) atlasWidth,
+                rY = (float) imageHeight / (float) atlasHeight,
+                oX = (float) ifile->getX() / (float) atlasWidth,
+                oY = 1.0f - ((float) (ifile->getY() + imageHeight) / (float) atlasHeight);
+
+    for (Vertex& v: mesh->vertices)
+    {
+        float x = v.texCoord[index].x;
+        x = oX + x*rX;
+        v.texCoord[index].x = x;
+
+        float y = v.texCoord[index].y;
+        y = oY + y*(1.0f - rY);
+        v.texCoord[index].y = y;
+    }
+}
+
+}

--- a/tools/encoder/src/TexturePacker.cpp
+++ b/tools/encoder/src/TexturePacker.cpp
@@ -315,7 +315,7 @@ bool TexturePacker::parse(string fileName)
                 if (!ifile)
                 {
                     LOG(1, "Cannot open image file - %s\n",
-                        ifile->getFileName().c_str());
+                        l.sparams[0].c_str());
                     return false;
                 }
                 struct AtlasItem ai = { .atlas = currentAtlas, .ifile = ifile };

--- a/tools/encoder/src/TexturePacker.cpp
+++ b/tools/encoder/src/TexturePacker.cpp
@@ -18,8 +18,8 @@
 
  #node idInGPBFile
  node item1
-	 uvmap 0, diffuse.png, item1.png #uvmap texCoordIndex, outputFile, inputFile
-	 uvmap 1, normal.png, itemN1.png
+     uvmap 0, diffuse.png, item1.png #uvmap texCoordIndex, outputFile, inputFile
+     uvmap 1, normal.png, itemN1.png
  node item2
      uvmap 0, diffuse.png, item1.png
      uvmap 1, normal.png, itemN2.png

--- a/tools/encoder/src/TexturePacker.cpp
+++ b/tools/encoder/src/TexturePacker.cpp
@@ -400,15 +400,15 @@ bool TexturePacker::parse(string fileName)
             continue;
         }
 
-        if (!ai.atlas->pack(ai.ifile))
+        if (ai.atlas->pack(ai.ifile))
         {
+            LOG(1, "\tPacked %s!\n", ai.ifile->getFileName().c_str());
+        } else {
             LOG(1, "Failed to pack image: %s\n",
                 ai.ifile->getFileName().c_str());
             delete ai.ifile;
             failed = true;
         }
-
-        LOG(1, "\tPacked %s!\n", ai.ifile->getFileName().c_str());
     }
 
     return !failed;

--- a/tools/encoder/src/TexturePacker.h
+++ b/tools/encoder/src/TexturePacker.h
@@ -1,0 +1,54 @@
+#ifndef __TEXTURE_PACKER_H
+#define __TEXTURE_PACKER_H
+
+#include <string>
+#include <map>
+#include <vector>
+
+namespace gameplay
+{
+
+class TextureAtlas;
+class GPBFile;
+
+class TexturePacker {
+public:
+    TexturePacker(GPBFile *gpbFile) : _gpbFile(gpbFile) {}
+    ~TexturePacker();
+    bool parse(std::string fileName);
+    bool write();
+private:
+    enum class LineType {
+        TextureAtlas,
+        Texture,
+        Node,
+        UVMap,
+    };
+
+    struct Line {
+        LineType type;
+        std::string sparams[3];
+        int paramsCount;
+    };
+
+    struct UVMapInfo {
+        std::string nodeId;
+        int texCoordIndex;
+        std::string textureAtlasName;
+        std::string textureName;
+    };
+
+    bool parseLine(std::string& str, Line& line);
+    typedef std::map<std::string, TextureAtlas*> AtlasMap;
+
+    void updateUV(UVMapInfo uvmapinfo);
+    AtlasMap _atlases;
+    std::vector<UVMapInfo> _uvmaps;
+    GPBFile *_gpbFile;
+
+    const std::string meshSuffix = "_Mesh";
+};
+
+}
+
+#endif /* __TEXTURE_PACKER_H */


### PR DESCRIPTION
with the `-tp <inputFile>` option separate texture files for different nodes in a GPB file are read from files and packed into a single texture atlas and the UV coordinates of the nodes are modified accordingly.

This saves a lot of time compared to doing the same thing manually. It can also be easily improved to pack UI theme textures. The packing algorithm is not a perfect one but should do the job for most cases.

Example input file is available at the top of `TexturePacker.cpp`.