### PR TITLE
Add shadow mapping example

### DIFF
--- a/samples/browser/res/common/duck.material
+++ b/samples/browser/res/common/duck.material
@@ -35,4 +35,25 @@ material duck
             }
         }
     }
+
+    technique depth
+    {
+        pass
+        {
+            // uniforms
+            u_depthRange = DEPTH_RANGE
+            u_worldViewProjectionMatrix = WORLD_VIEW_PROJECTION_MATRIX
+
+            // shaders
+            vertexShader = res/shaders/depth.vert
+            fragmentShader = res/shaders/depth.frag
+
+            // render state
+            renderState
+            {
+                cullFace = true
+                depthTest = true
+            }
+        }
+    }
 }

--- a/samples/browser/res/common/physics.material
+++ b/samples/browser/res/common/physics.material
@@ -25,7 +25,7 @@ material colored
         pass
         {
             // uniforms
-            u_depthRange = DEPTH_RANGE
+            u_depthRange = SHADOW_DEPTH_RANGE
             u_worldViewProjectionMatrix = WORLD_VIEW_PROJECTION_MATRIX
 
             // shaders
@@ -51,8 +51,8 @@ material floor : colored
             defines = DIRECTIONAL_LIGHT_COUNT 1;SHADOW_MAPPING
             u_worldMatrix = WORLD_MATRIX
             u_shadowMap = SHADOW_MAP
-            u_pixelOffset = PIXEL_OFFSET
-            u_depthRange = DEPTH_RANGE
+            u_pixelOffset = SHADOW_PIXEL_OFFSET
+            u_depthRange = SHADOW_DEPTH_RANGE
             u_shadowTextureMatrix = SHADOW_TEXTURE_MATRIX
 
             u_diffuseColor = 0.5, 0.5, 0.5, 1

--- a/samples/browser/res/common/physics.material
+++ b/samples/browser/res/common/physics.material
@@ -7,11 +7,32 @@ material colored
             vertexShader = res/shaders/colored.vert
             fragmentShader = res/shaders/colored.frag
             defines = DIRECTIONAL_LIGHT_COUNT 1
-            
+
             // uniforms
             u_worldViewProjectionMatrix = WORLD_VIEW_PROJECTION_MATRIX
             u_inverseTransposeWorldViewMatrix = INVERSE_TRANSPOSE_WORLD_VIEW_MATRIX
-            
+
+            renderState
+            {
+                cullFace = true
+                depthTest = true
+            }
+        }
+    }
+
+    technique depth
+    {
+        pass
+        {
+            // uniforms
+            u_depthRange = DEPTH_RANGE
+            u_worldViewProjectionMatrix = WORLD_VIEW_PROJECTION_MATRIX
+
+            // shaders
+            vertexShader = res/shaders/depth.vert
+            fragmentShader = res/shaders/depth.frag
+
+            // render state
             renderState
             {
                 cullFace = true
@@ -27,7 +48,16 @@ material floor : colored
     {
         pass
         {
+            defines = DIRECTIONAL_LIGHT_COUNT 1;SHADOW_MAPPING
+            u_worldMatrix = WORLD_MATRIX
+            u_shadowMap = SHADOW_MAP
+            u_pixelOffset = PIXEL_OFFSET
+            u_depthRange = DEPTH_RANGE
+            u_shadowTextureMatrix = SHADOW_TEXTURE_MATRIX
+
             u_diffuseColor = 0.5, 0.5, 0.5, 1
+            vertexShader = res/shaders/colored-shadowmapped.vert
+            fragmentShader = res/shaders/colored-shadowmapped.frag
         }
     }
 }

--- a/samples/browser/res/common/physics.scene
+++ b/samples/browser/res/common/physics.scene
@@ -15,8 +15,13 @@ scene
 	{
 		material = res/common/physics.material#floor
 		collisionObject = res/common/physics.physics#staticBox
+
+        tags
+        {
+            noShadowCast
+        }
 	}
-	
+
 	node wall01
 	{
 		material = res/common/physics.material#floor

--- a/samples/browser/res/shaders/colored-shadowmapped.frag
+++ b/samples/browser/res/shaders/colored-shadowmapped.frag
@@ -1,0 +1,204 @@
+#ifdef OPENGL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp float;
+#else
+precision mediump float;
+#endif
+#endif
+
+#ifndef DIRECTIONAL_LIGHT_COUNT
+#define DIRECTIONAL_LIGHT_COUNT 0
+#endif
+#ifndef SPOT_LIGHT_COUNT
+#define SPOT_LIGHT_COUNT 0
+#endif
+#ifndef POINT_LIGHT_COUNT
+#define POINT_LIGHT_COUNT 0
+#endif
+#if (DIRECTIONAL_LIGHT_COUNT > 0) || (POINT_LIGHT_COUNT > 0) || (SPOT_LIGHT_COUNT > 0)
+#define LIGHTING
+#endif
+
+///////////////////////////////////////////////////////////
+// Uniforms
+uniform vec3 u_ambientColor;
+uniform vec4 u_diffuseColor;
+
+#if defined(LIGHTMAP)
+uniform sampler2D u_lightmapTexture;
+#endif
+
+#if defined(LIGHTING)
+
+#if (DIRECTIONAL_LIGHT_COUNT > 0)
+uniform vec3 u_directionalLightColor[DIRECTIONAL_LIGHT_COUNT];
+uniform vec3 u_directionalLightDirection[DIRECTIONAL_LIGHT_COUNT];
+#endif
+
+#if (POINT_LIGHT_COUNT > 0)
+uniform vec3 u_pointLightColor[POINT_LIGHT_COUNT];
+uniform vec3 u_pointLightPosition[POINT_LIGHT_COUNT];
+uniform float u_pointLightRangeInverse[POINT_LIGHT_COUNT];
+#endif
+
+#if (SPOT_LIGHT_COUNT > 0)
+uniform vec3 u_spotLightColor[SPOT_LIGHT_COUNT];
+uniform vec3 u_spotLightDirection[SPOT_LIGHT_COUNT];
+uniform float u_spotLightRangeInverse[SPOT_LIGHT_COUNT];
+uniform float u_spotLightInnerAngleCos[SPOT_LIGHT_COUNT];
+uniform float u_spotLightOuterAngleCos[SPOT_LIGHT_COUNT];
+#endif
+
+#if defined(SPECULAR)
+uniform float u_specularExponent;
+#endif
+
+#endif
+
+#if defined(MODULATE_COLOR)
+uniform vec4 u_modulateColor;
+#endif
+
+#if defined(MODULATE_ALPHA)
+uniform float u_modulateAlpha;
+#endif
+
+#if defined(SHADOW_MAPPING)
+uniform float       u_pixelOffset; // 1.0 / shadow_texture_size
+uniform sampler2D   u_shadowMap;
+#endif
+
+///////////////////////////////////////////////////////////
+// Variables
+vec4 _baseColor;
+
+///////////////////////////////////////////////////////////
+// Varyings
+#if defined(VERTEX_COLOR)
+varying vec3 v_color;
+#endif
+
+#if defined(LIGHTMAP)
+varying vec2 v_texCoord1;
+#endif
+
+#if defined(LIGHTING)
+
+varying vec3 v_normalVector;
+
+#if (POINT_LIGHT_COUNT > 0)
+varying vec3 v_vertexToPointLightDirection[POINT_LIGHT_COUNT];
+#endif
+
+#if (SPOT_LIGHT_COUNT > 0)
+varying vec3 v_vertexToSpotLightDirection[SPOT_LIGHT_COUNT];
+#endif
+
+#if defined(SPECULAR)
+varying vec3 v_cameraDirection; 
+#endif
+
+#include "lighting.frag"
+
+#endif
+
+#if defined(CLIP_PLANE)
+varying float v_clipDistance;
+#endif
+
+#if defined(SHADOW_MAPPING)
+varying vec4 v_shadowTexCoord;
+
+// Tweakable consts
+const float gradientClamp       = 0.0098;
+const float gradientScaleBias   = 0.0;
+const float fixedDepthBias      = 0.0005;
+const vec2 texDims = vec2(512.0, 512.0);
+
+// Ported from http://http.developer.nvidia.com/GPUGems/gpugems_ch12.html
+// Unpacks a float from RGBA texture
+float getDepth(vec2 uv)
+{
+    vec4 depthPacked = texture2D(u_shadowMap, uv);
+    return depthPacked.r / 1.0 +
+    depthPacked.g / 256.0 +
+    depthPacked.b / 65536.0 +
+    depthPacked.a / 16777216.0;
+}
+
+// Ported from: http://www.ogre3d.org/tikiwiki/tiki-index.php?page=Depth+Shadow+Mapping
+float getShadowValue()
+{
+    float shadowTerm = 0.0;
+    vec4 shadowUV = v_shadowTexCoord;
+    shadowUV.xy = shadowUV.xy / shadowUV.w;
+    float centerdepth = getDepth(shadowUV.xy);
+    // gradient calculation
+    vec4 depths = vec4( getDepth(shadowUV.xy + vec2(-u_pixelOffset, 0)),
+                       getDepth(shadowUV.xy + vec2(+u_pixelOffset, 0)),
+                       getDepth(shadowUV.xy + vec2(0, -u_pixelOffset)),
+                       getDepth(shadowUV.xy + vec2(0, +u_pixelOffset)) );
+    vec2 differences = abs( depths.yw - depths.xz );
+    float gradient = min(gradientClamp, max(differences.x, differences.y));
+    float gradientFactor = gradient * gradientScaleBias;
+    // visibility function
+    float depthAdjust = gradientFactor + (fixedDepthBias * centerdepth);
+    float finalCenterDepth = centerdepth + depthAdjust;
+    // PCF
+    depths += depthAdjust;
+    float final = step(finalCenterDepth, shadowUV.z) * 0.5 + 0.5;
+    bvec4 vecCmp = greaterThan(depths, vec4(shadowUV.z));
+    final += float(vecCmp.x) * 0.5 + 0.5;
+    final += float(vecCmp.y) * 0.5 + 0.5;
+    final += float(vecCmp.z) * 0.5 + 0.5;
+    final += float(vecCmp.w) * 0.5 + 0.5;
+    final *= 0.2;
+    return final;
+}
+#endif
+
+void main()
+{
+    #if defined(CLIP_PLANE)
+    if(v_clipDistance < 0.0) discard;
+    #endif
+ 
+    #if defined(LIGHTING)
+
+    #if defined(VERTEX_COLOR)
+	_baseColor.rgb = v_color;
+    #else
+    _baseColor = u_diffuseColor;
+	#endif
+    
+    gl_FragColor.a = _baseColor.a;
+    gl_FragColor.rgb = getLitPixel();
+    
+    #else
+    
+    #if defined(VERTEX_COLOR)
+    gl_FragColor.rgb = v_color;
+    gl_FragColor.a = 1.0;
+    #else
+    gl_FragColor = u_diffuseColor;
+    #endif
+    
+    #endif
+
+	#if defined(LIGHTMAP)
+	vec4 lightColor = texture2D(u_lightmapTexture, v_texCoord1);
+	gl_FragColor.rgb *= lightColor.rgb;
+	#endif
+
+	#if defined(MODULATE_COLOR)
+    gl_FragColor *= u_modulateColor;
+    #endif
+
+	#if defined(MODULATE_ALPHA)
+    gl_FragColor.a *= u_modulateAlpha;
+    #endif
+
+    #if defined(SHADOW_MAPPING)
+    gl_FragColor.rgb *= getShadowValue();
+    #endif
+}

--- a/samples/browser/res/shaders/colored-shadowmapped.frag
+++ b/samples/browser/res/shaders/colored-shadowmapped.frag
@@ -146,14 +146,14 @@ float getShadowValue()
     float finalCenterDepth = centerdepth + depthAdjust;
     // PCF
     depths += depthAdjust;
-    float final = step(finalCenterDepth, shadowUV.z) * 0.5 + 0.5;
+    float final = step(finalCenterDepth, shadowUV.z);
     bvec4 vecCmp = greaterThan(depths, vec4(shadowUV.z));
-    final += float(vecCmp.x) * 0.5 + 0.5;
-    final += float(vecCmp.y) * 0.5 + 0.5;
-    final += float(vecCmp.z) * 0.5 + 0.5;
-    final += float(vecCmp.w) * 0.5 + 0.5;
-    final *= 0.2;
-    return final;
+    final += float(vecCmp.x);
+    final += float(vecCmp.y);
+    final += float(vecCmp.z);
+    final += float(vecCmp.w);
+    final *= 0.1;
+    return final + 0.6;
 }
 #endif
 

--- a/samples/browser/res/shaders/colored-shadowmapped.vert
+++ b/samples/browser/res/shaders/colored-shadowmapped.vert
@@ -1,0 +1,165 @@
+#ifndef DIRECTIONAL_LIGHT_COUNT
+#define DIRECTIONAL_LIGHT_COUNT 0
+#endif
+#ifndef SPOT_LIGHT_COUNT
+#define SPOT_LIGHT_COUNT 0
+#endif
+#ifndef POINT_LIGHT_COUNT
+#define POINT_LIGHT_COUNT 0
+#endif
+#if (DIRECTIONAL_LIGHT_COUNT > 0) || (POINT_LIGHT_COUNT > 0) || (SPOT_LIGHT_COUNT > 0)
+#define LIGHTING
+#endif
+
+///////////////////////////////////////////////////////////
+// Attributes
+attribute vec4 a_position;
+
+#if defined(SKINNING)
+attribute vec4 a_blendWeights;
+attribute vec4 a_blendIndices;
+#endif
+
+#if defined(LIGHTMAP)
+attribute vec2 a_texCoord1;
+#endif
+
+#if defined(LIGHTING)
+attribute vec3 a_normal;
+#endif
+
+#if defined(VERTEX_COLOR)
+attribute vec3 a_color;
+#endif
+
+///////////////////////////////////////////////////////////
+// Uniforms
+uniform mat4 u_worldViewProjectionMatrix;
+
+#if defined(SKINNING)
+uniform vec4 u_matrixPalette[SKINNING_JOINT_COUNT * 3];
+#endif
+
+#if defined(LIGHTING)
+uniform mat4 u_inverseTransposeWorldViewMatrix;
+
+#if (POINT_LIGHT_COUNT > 0) || (SPOT_LIGHT_COUNT > 0) || defined(SPECULAR)
+uniform mat4 u_worldViewMatrix;
+#endif
+
+#if (DIRECTIONAL_LIGHT_COUNT > 0)
+uniform vec3 u_directionalLightDirection[DIRECTIONAL_LIGHT_COUNT];
+#endif
+
+#if (POINT_LIGHT_COUNT > 0) 
+uniform vec3 u_pointLightPosition[POINT_LIGHT_COUNT];
+#endif
+
+#if (SPOT_LIGHT_COUNT > 0)
+uniform vec3 u_spotLightPosition[SPOT_LIGHT_COUNT];
+uniform vec3 u_spotLightDirection[SPOT_LIGHT_COUNT];
+#endif
+
+#if defined(SPECULAR)
+uniform vec3 u_cameraPosition;
+#endif
+
+#endif
+
+#if defined(CLIP_PLANE)
+uniform mat4 u_worldMatrix;
+uniform vec4 u_clipPlane;
+#endif
+
+#if defined(SHADOW_MAPPING)
+uniform mat4 u_worldMatrix;
+uniform mat4 u_shadowTextureMatrix;
+uniform vec2 u_depthRange; // x: nearPlane; y: 1.0 / (farPlane - nearPlane);
+#endif
+
+///////////////////////////////////////////////////////////
+// Varyings
+#if defined(LIGHTMAP)
+varying vec2 v_texCoord1;
+#endif
+
+#if defined(VERTEX_COLOR)
+varying vec3 v_color;
+#endif
+
+#if defined(LIGHTING)
+
+varying vec3 v_normalVector;
+
+#if (DIRECTIONAL_LIGHT_COUNT > 0) 
+varying vec3 v_lightDirection[DIRECTIONAL_LIGHT_COUNT];
+#endif
+
+#if (POINT_LIGHT_COUNT > 0)
+varying vec3 v_vertexToPointLightDirection[POINT_LIGHT_COUNT];
+#endif
+
+#if (SPOT_LIGHT_COUNT > 0)
+varying vec3 v_vertexToSpotLightDirection[SPOT_LIGHT_COUNT];
+#endif
+
+#if defined(SPECULAR)
+varying vec3 v_cameraDirection;
+#endif
+
+#include "lighting.vert"
+
+#endif
+
+#if defined(SKINNING)
+#include "skinning.vert"
+#else
+#include "skinning-none.vert" 
+#endif
+
+#if defined(CLIP_PLANE)
+varying float v_clipDistance;
+#endif
+
+#if defined(SHADOW_MAPPING)
+varying vec4 v_shadowTexCoord;
+#endif
+
+void main()
+{
+    vec4 position = getPosition();
+    gl_Position = u_worldViewProjectionMatrix * position;
+
+    #if defined (LIGHTING)
+
+    vec3 normal = getNormal();
+
+    // Transform normal to view space.
+    mat3 inverseTransposeWorldViewMatrix = mat3(u_inverseTransposeWorldViewMatrix[0].xyz, u_inverseTransposeWorldViewMatrix[1].xyz, u_inverseTransposeWorldViewMatrix[2].xyz);
+    v_normalVector = inverseTransposeWorldViewMatrix * normal;
+
+    // Apply light.
+    applyLight(position);
+
+    #endif
+
+    // Pass the lightmap texture coordinate
+    #if defined(LIGHTMAP)
+    v_texCoord1 = a_texCoord1;
+    #endif
+    
+    // Pass the vertex color
+    #if defined(VERTEX_COLOR)
+	v_color = a_color;
+    #endif
+    
+    #if defined(CLIP_PLANE)
+    v_clipDistance = dot(u_worldMatrix * position, u_clipPlane);
+    #endif
+
+    #if defined(SHADOW_MAPPING)
+    vec4 worldPos      = u_worldMatrix * position;
+    v_shadowTexCoord   = u_shadowTextureMatrix * worldPos;
+    v_shadowTexCoord.z = (v_shadowTexCoord.z - u_depthRange.x) * u_depthRange.y;
+    #endif
+}

--- a/samples/browser/res/shaders/depth.frag
+++ b/samples/browser/res/shaders/depth.frag
@@ -1,0 +1,23 @@
+#ifdef OPENGL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp float;
+#else
+precision mediump float;
+#endif
+#endif
+
+varying float v_depth;
+
+// Ported from http://http.developer.nvidia.com/GPUGems/gpugems_ch12.html
+// Packs a float into RGBA texture
+vec4 pack (float depth)
+{
+    const vec4 vPack = vec4(1.0, 256.0, 65536.0, 16777216.0);
+    return vPack * depth;
+}
+
+
+void main()
+{
+    gl_FragColor = pack(v_depth);
+}

--- a/samples/browser/res/shaders/depth.vert
+++ b/samples/browser/res/shaders/depth.vert
@@ -1,0 +1,16 @@
+// Inputs
+attribute vec4 a_position;
+
+// Uniforms
+uniform mat4 u_worldViewProjectionMatrix;
+uniform vec2 u_depthRange; // x: nearPlane; y: 1.0 / (farPlane - nearPlane);
+
+// Outputs
+varying float v_depth;
+
+void main()
+{
+    vec4 position = a_position;
+    gl_Position = u_worldViewProjectionMatrix * position;
+    v_depth = (gl_Position.z - u_depthRange.x) * u_depthRange.y;
+}

--- a/samples/browser/src/PhysicsCollisionObjectSample.cpp
+++ b/samples/browser/src/PhysicsCollisionObjectSample.cpp
@@ -63,7 +63,7 @@ void PhysicsCollisionObjectSample::initialize()
     _lightNode->addChild(shadowCamNode);
     _shadowCam = Camera::createOrthographic(20, 20, getAspectRatio(), 0.0f, 50.0f);
     shadowCamNode->setCamera(_shadowCam);
-    _depthRange.set(_shadowCam->getNearPlane(), 1.0f / (_shadowCam->getFarPlane() - _shadowCam->getNearPlane()));
+    _shadowDepthRange.set(_shadowCam->getNearPlane(), 1.0f / (_shadowCam->getFarPlane() - _shadowCam->getNearPlane()));
     SAFE_RELEASE(shadowCamNode);
 }
 
@@ -271,14 +271,14 @@ void PhysicsCollisionObjectSample::controlEvent(Control* control, EventType evt)
 
 bool PhysicsCollisionObjectSample::resolveAutoBinding(const char *autoBinding, Node *node, MaterialParameter *parameter)
 {
-    if (strcmp(autoBinding, "DEPTH_RANGE") == 0)
+    if (strcmp(autoBinding, "SHADOW_DEPTH_RANGE") == 0)
     {
-        parameter->bindValue(this, &PhysicsCollisionObjectSample::getDepthRange);
+        parameter->bindValue(this, &PhysicsCollisionObjectSample::getShadowDepthRange);
         return true;
     }
-    else if (strcmp(autoBinding, "PIXEL_OFFSET") == 0)
+    else if (strcmp(autoBinding, "SHADOW_PIXEL_OFFSET") == 0)
     {
-        parameter->bindValue(this, &PhysicsCollisionObjectSample::getPixelOffset);
+        parameter->bindValue(this, &PhysicsCollisionObjectSample::getShadowPixelOffset);
         return true;
     }
     else if (strcmp(autoBinding, "SHADOW_MAP") == 0)

--- a/samples/browser/src/PhysicsCollisionObjectSample.h
+++ b/samples/browser/src/PhysicsCollisionObjectSample.h
@@ -71,14 +71,14 @@ private:
     FrameBuffer *_shadowMapFB;
     Texture::Sampler *_shadowSampler;
     Texture::Sampler* getShadowSampler() const { return _shadowSampler; }
-    Vector2 _depthRange;
+    Vector2 _shadowDepthRange;
     Camera *_shadowCam;
     Rectangle _shadowViewport;
     Matrix _shadowMatrix;
     Matrix getShadowMatrix() const { return _shadowMatrix; }
-    Vector2 getDepthRange() const { return _depthRange; }
-    float _pixelOffset;
-    float getPixelOffset() const { return _pixelOffset; }
+    Vector2 getShadowDepthRange() const { return _shadowDepthRange; }
+    float _shadowPixelOffset;
+    float getShadowPixelOffset() const { return _shadowPixelOffset; }
     bool drawShadowNode(Node *node);
     void drawShadowMap();
 };

--- a/samples/browser/src/PhysicsCollisionObjectSample.h
+++ b/samples/browser/src/PhysicsCollisionObjectSample.h
@@ -9,7 +9,7 @@ using namespace gameplay;
 /**
  * Sample loading a physics scene from .scene file with .physics bindings
  */
-class PhysicsCollisionObjectSample : public Sample, Control::Listener
+class PhysicsCollisionObjectSample : public Sample, Control::Listener, RenderState::AutoBindingResolver
 {
 public:
 
@@ -20,6 +20,8 @@ public:
     void keyEvent(Keyboard::KeyEvent evt, int key);
 
     void controlEvent(Control* control, EventType evt);
+
+    bool resolveAutoBinding(const char* autoBinding, Node* node, MaterialParameter* parameter);
 
 protected:
 
@@ -55,6 +57,7 @@ private:
     Scene* _scene;
     Node* _lightNode;
     Form* _form;
+
     int _objectType;
     bool _throw;
     int _drawDebug;
@@ -63,6 +66,21 @@ private:
     std::vector<const char*> _nodeIds;
     std::vector<const char*> _nodeNames;
     std::vector<Vector4> _colors;
+
+    //Shadow mapping stuff
+    FrameBuffer *_shadowMapFB;
+    Texture::Sampler *_shadowSampler;
+    Texture::Sampler* getShadowSampler() const { return _shadowSampler; }
+    Vector2 _depthRange;
+    Camera *_shadowCam;
+    Rectangle _shadowViewport;
+    Matrix _shadowMatrix;
+    Matrix getShadowMatrix() const { return _shadowMatrix; }
+    Vector2 getDepthRange() const { return _depthRange; }
+    float _pixelOffset;
+    float getPixelOffset() const { return _pixelOffset; }
+    bool drawShadowNode(Node *node);
+    void drawShadowMap();
 };
 
 #endif


### PR DESCRIPTION
I modified the PhysicsCollisionObjectSample from the sample-browser to have some basic PCF shadow mapping. It has glitches with objects to the edges because of texture clamping mode(no texture border color in GL ES). It's mainly based on the implementation that was once posted in the forums.