### PR TITLE
Fix for app freeze when user tries to hide keyboard on android

### DIFF
--- a/gameplay/src/PlatformAndroid.cpp
+++ b/gameplay/src/PlatformAndroid.cpp
@@ -44,7 +44,6 @@ static int __orientationAngle = 90;
 static bool __multiSampling = false;
 static bool __multiTouch = false;
 static int __primaryTouchId = -1;
-static bool __displayKeyboard = false;
 
 // OpenGL VAO functions.
 static const char* __glExtensions;
@@ -1400,9 +1399,6 @@ int Platform::enterMessagePump()
                 }
             }
         }
-            
-        // Display the keyboard.
-        gameplay::displayKeyboard(__state, __displayKeyboard);
     }
     return 0;
 }
@@ -1604,10 +1600,7 @@ bool Platform::isCursorVisible()
 
 void Platform::displayKeyboard(bool display)
 {
-    if (display)
-        __displayKeyboard = true;
-    else
-        __displayKeyboard = false;
+    gameplay::displayKeyboard(__state, display);
 }
 
 void Platform::shutdownInternal()

--- a/gameplay/src/PlatformAndroid.cpp
+++ b/gameplay/src/PlatformAndroid.cpp
@@ -44,7 +44,7 @@ static int __orientationAngle = 90;
 static bool __multiSampling = false;
 static bool __multiTouch = false;
 static int __primaryTouchId = -1;
-static bool __keyboardIsVisible = false;
+static bool __displayKeyboard = false;
 
 // OpenGL VAO functions.
 static const char* __glExtensions;
@@ -431,8 +431,6 @@ static void displayKeyboard(android_app* state, bool show)
     
     // Finished with the JVM.
     jvm->DetachCurrentThread(); 
-
-    __keyboardIsVisible = show;
 }
 
 // Gets the Keyboard::Key enumeration constant that corresponds to the given Android key code.
@@ -763,7 +761,7 @@ static int32_t engine_handle_input(struct android_app* app, AInputEvent* event)
     if (AInputEvent_getType(event) == AINPUT_EVENT_TYPE_KEY
         && AKeyEvent_getAction(event) == AKEY_EVENT_ACTION_DOWN
         && AKeyEvent_getKeyCode(event) == AKEYCODE_BACK
-        && __keyboardIsVisible
+        && __displayKeyboard
         )
     {
         Game::getInstance()->displayKeyboard(false);
@@ -1448,6 +1446,9 @@ int Platform::enterMessagePump()
                 }
             }
         }
+
+        // Display the keyboard.
+        gameplay::displayKeyboard(__state, __displayKeyboard);
     }
     return 0;
 }
@@ -1649,7 +1650,10 @@ bool Platform::isCursorVisible()
 
 void Platform::displayKeyboard(bool display)
 {
-    gameplay::displayKeyboard(__state, display);
+    if (display)
+        __displayKeyboard = true;
+    else
+        __displayKeyboard = false;
 }
 
 void Platform::shutdownInternal()

--- a/gameplay/src/PlatformAndroid.cpp
+++ b/gameplay/src/PlatformAndroid.cpp
@@ -768,8 +768,6 @@ static int32_t engine_handle_input(struct android_app* app, AInputEvent* event)
         return 1;
     }
 
-    Game::getInstance()->handlePlatformEvent(event);
-
     int32_t deviceId = AInputEvent_getDeviceId(event);
     int32_t source = AInputEvent_getSource(event);
 

--- a/gameplay/src/PlatformAndroid.cpp
+++ b/gameplay/src/PlatformAndroid.cpp
@@ -768,7 +768,7 @@ static int32_t engine_handle_input(struct android_app* app, AInputEvent* event)
         return 1;
     }
 
-	Game::getInstance()->handlePlatformEvent(event);
+    Game::getInstance()->handlePlatformEvent(event);
 
     int32_t deviceId = AInputEvent_getDeviceId(event);
     int32_t source = AInputEvent_getSource(event);
@@ -1262,7 +1262,8 @@ static void engine_handle_cmd(struct android_app* app, int32_t cmd)
 static void process_input( struct android_app* app, struct android_poll_source* source)
 {
     AInputEvent* event = NULL;
-    if (AInputQueue_getEvent(app->inputQueue, &event) >= 0)
+
+    while(AInputQueue_getEvent(app->inputQueue, &event) >= 0)
     {
         int type = AInputEvent_getType(event);
         LOGV("New input event: type=%d\n", AInputEvent_getType(event));
@@ -1279,8 +1280,6 @@ static void process_input( struct android_app* app, struct android_poll_source* 
         if (app->onInputEvent != NULL)
             handled = app->onInputEvent(app, event);
         AInputQueue_finishEvent(app->inputQueue, event, handled);
-    } else {
-        LOGE("Failure reading next input event: %s\n", strerror(errno));
     }
 }
 


### PR DESCRIPTION
Tested on Android 4.1, 4.2 and 5.0. This fixes #1626 

See: http://stackoverflow.com/questions/15913080/crash-when-closing-soft-keyboard-while-using-native-activity