### PR TITLE
Enable using VAOs on Android

### DIFF
--- a/gameplay/src/Base.h
+++ b/gameplay/src/Base.h
@@ -220,6 +220,7 @@ using std::va_list;
     #define GL_DEPTH24_STENCIL8 GL_DEPTH24_STENCIL8_OES
     #define glClearDepth glClearDepthf
     #define OPENGL_ES
+    #define GP_USE_VAO
 #elif WIN32
         #define WIN32_LEAN_AND_MEAN
         #define GLEW_STATIC

--- a/gameplay/src/PlatformAndroid.cpp
+++ b/gameplay/src/PlatformAndroid.cpp
@@ -325,7 +325,6 @@ static bool initEGL()
     
     if (strstr(__glExtensions, "GL_OES_vertex_array_object") || strstr(__glExtensions, "GL_ARB_vertex_array_object"))
     {
-        // Disable VAO extension for now.
         glBindVertexArray = (PFNGLBINDVERTEXARRAYOESPROC)eglGetProcAddress("glBindVertexArrayOES");
         glDeleteVertexArrays = (PFNGLDELETEVERTEXARRAYSOESPROC)eglGetProcAddress("glDeleteVertexArraysOES");
         glGenVertexArrays = (PFNGLGENVERTEXARRAYSOESPROC)eglGetProcAddress("glGenVertexArraysOES");


### PR DESCRIPTION
Was there a good reason for disabling those? I've tried on a few devices with different GPUs today and it seems to work fine. 

According to this database, quite many devices support GL_OES_vertex_array_object: http://delphigl.de/glcapsviewer/gles_listreports.php?extension=GL_OES_vertex_array_object