### PR TITLE
UI fixes (mostly related to parent container updating)

### DIFF
--- a/gameplay/src/Container.cpp
+++ b/gameplay/src/Container.cpp
@@ -425,6 +425,7 @@ const Vector2& Container::getScrollPosition() const
 void Container::setScrollPosition(const Vector2& scrollPosition)
 {
     _scrollPosition = scrollPosition;
+    setChildrenDirty(DIRTY_BOUNDS, true);
 }
 
 Animation* Container::getAnimation(const char* id) const

--- a/gameplay/src/Container.cpp
+++ b/gameplay/src/Container.cpp
@@ -555,7 +555,7 @@ void Container::updateBounds()
                 Control* ctrl = _controls[i];
                 if (ctrl->isVisible() && !ctrl->isXPercentage() && !ctrl->isWidthPercentage())
                 {
-                    float w = ctrl->getWidth();
+                    float w = ctrl->getWidth() + ctrl->getMargin().right;
                     if (!ctrl->isXPercentage())
                         w += ctrl->getX();
                     if (width < w)
@@ -575,7 +575,7 @@ void Container::updateBounds()
                 Control* ctrl = _controls[i];
                 if (ctrl->isVisible() && !ctrl->isYPercentage() && !ctrl->isHeightPercentage())
                 {
-                    float h = ctrl->getHeight();
+                    float h = ctrl->getHeight() + ctrl->getMargin().bottom;
                     if (!ctrl->isYPercentage())
                         h += ctrl->getY();
                     if (height < h)

--- a/gameplay/src/Container.cpp
+++ b/gameplay/src/Container.cpp
@@ -543,9 +543,6 @@ void Container::updateState(State state)
 
 void Container::updateBounds()
 {
-    // Compute total bounds of container
-    Control::updateBounds();
-
     // Handle automatically sizing based on our children
     if (_autoSize != AUTO_SIZE_NONE)
     {
@@ -589,6 +586,9 @@ void Container::updateBounds()
             setHeightInternal(height);
         }
     }
+
+    // Compute total bounds of container
+    Control::updateBounds();
 
     // Update layout to position children correctly within us
     GP_ASSERT(_layout);

--- a/gameplay/src/Container.cpp
+++ b/gameplay/src/Container.cpp
@@ -1138,33 +1138,34 @@ void Container::updateScroll()
     }
 
     // Stop scrolling when the far edge is reached.
+    Vector2 lastScrollPosition(_scrollPosition);
+
     if (-_scrollPosition.x > _totalWidth - clipWidth)
     {
         _scrollPosition.x = -(_totalWidth - clipWidth);
         _scrollingVelocity.x = 0;
-        dirty = true;
     }
     
     if (-_scrollPosition.y > _totalHeight - clipHeight)
     {
         _scrollPosition.y = -(_totalHeight - clipHeight);
         _scrollingVelocity.y = 0;
-        dirty = true;
     }
 
     if (_scrollPosition.x > 0)
     {
         _scrollPosition.x = 0;
         _scrollingVelocity.x = 0;
-        dirty = true;
     }
 
     if (_scrollPosition.y > 0)
     {
         _scrollPosition.y = 0;
         _scrollingVelocity.y = 0;
-        dirty = true;
     }
+
+    if (_scrollPosition != lastScrollPosition)
+        dirty = true;
 
     float scrollWidth = 0;
     if (clipWidth < _totalWidth)

--- a/gameplay/src/Container.cpp
+++ b/gameplay/src/Container.cpp
@@ -425,6 +425,7 @@ const Vector2& Container::getScrollPosition() const
 void Container::setScrollPosition(const Vector2& scrollPosition)
 {
     _scrollPosition = scrollPosition;
+    setDirty(DIRTY_BOUNDS);
     setChildrenDirty(DIRTY_BOUNDS, true);
 }
 
@@ -553,7 +554,7 @@ void Container::updateBounds()
             for (size_t i = 0, count = _controls.size(); i < count; ++i)
             {
                 Control* ctrl = _controls[i];
-                if (ctrl->isVisible() && !ctrl->isXPercentage() && !ctrl->isWidthPercentage())
+                if (ctrl->isVisible() && !ctrl->isWidthPercentage())
                 {
                     float w = ctrl->getWidth() + ctrl->getMargin().right;
                     if (!ctrl->isXPercentage())
@@ -573,7 +574,7 @@ void Container::updateBounds()
             for (size_t i = 0, count = _controls.size(); i < count; ++i)
             {
                 Control* ctrl = _controls[i];
-                if (ctrl->isVisible() && !ctrl->isYPercentage() && !ctrl->isHeightPercentage())
+                if (ctrl->isVisible() && !ctrl->isHeightPercentage())
                 {
                     float h = ctrl->getHeight() + ctrl->getMargin().bottom;
                     if (!ctrl->isYPercentage())

--- a/gameplay/src/Container.cpp
+++ b/gameplay/src/Container.cpp
@@ -1087,6 +1087,9 @@ void Container::updateScroll()
     {
         Control* control = _controls[i];
 
+        if (!control->isVisible())
+            continue;
+
         const Rectangle& bounds = control->getBounds();
         const Theme::Margin& margin = control->getMargin();
 

--- a/gameplay/src/Container.cpp
+++ b/gameplay/src/Container.cpp
@@ -1292,6 +1292,7 @@ bool Container::touchEventScroll(Touch::TouchEvent evt, int x, int y, unsigned i
             _scrollingLastTime = gameTime;
             setDirty(DIRTY_BOUNDS);
             setChildrenDirty(DIRTY_BOUNDS, true);
+            updateScroll();
             return false;
         }
         break;

--- a/gameplay/src/Container.cpp
+++ b/gameplay/src/Container.cpp
@@ -636,7 +636,7 @@ bool Container::updateChildBounds()
             if (changed)
             {
                 Control* parent = this;
-                while (parent && parent->_autoSize != AUTO_SIZE_NONE)
+                while (parent && (parent->_autoSize != AUTO_SIZE_NONE || static_cast<Container *>(parent)->getLayout()->getType() != Layout::LAYOUT_ABSOLUTE))
                 {
                     parent->setDirty(DIRTY_BOUNDS);
                     parent = parent->_parent;

--- a/gameplay/src/Container.cpp
+++ b/gameplay/src/Container.cpp
@@ -556,7 +556,7 @@ void Container::updateBounds()
             for (size_t i = 0, count = _controls.size(); i < count; ++i)
             {
                 Control* ctrl = _controls[i];
-                if (ctrl->isVisible() && !ctrl->isWidthPercentage())
+                if (ctrl->isVisible() && !ctrl->isXPercentage() && !ctrl->isWidthPercentage())
                 {
                     float w = ctrl->getWidth();
                     if (!ctrl->isXPercentage())
@@ -576,7 +576,7 @@ void Container::updateBounds()
             for (size_t i = 0, count = _controls.size(); i < count; ++i)
             {
                 Control* ctrl = _controls[i];
-                if (ctrl->isVisible() && !ctrl->isHeightPercentage())
+                if (ctrl->isVisible() && !ctrl->isYPercentage() && !ctrl->isHeightPercentage())
                 {
                     float h = ctrl->getHeight();
                     if (!ctrl->isYPercentage())

--- a/gameplay/src/Control.cpp
+++ b/gameplay/src/Control.cpp
@@ -1132,14 +1132,14 @@ bool Control::updateBoundsInternal(const Vector2& offset)
         _dirtyBits &= ~DIRTY_STATE;
     }
 
-    // Clear our dirty bounds bit
-    bool dirtyBounds = (_dirtyBits & DIRTY_BOUNDS) != 0;
-    _dirtyBits &= ~DIRTY_BOUNDS;
-
     // If we are a container, always update child bounds first
     bool changed = false;
     if (isContainer())
         changed = static_cast<Container*>(this)->updateChildBounds();
+
+    // Clear our dirty bounds bit
+    bool dirtyBounds = (_dirtyBits & DIRTY_BOUNDS) != 0;
+    _dirtyBits &= ~DIRTY_BOUNDS;
 
     if (dirtyBounds)
     {
@@ -1172,12 +1172,14 @@ void Control::updateBounds()
 
     const Rectangle parentAbsoluteBounds = _parent ? _parent->_viewportBounds : Rectangle(0, 0, game->getViewport().width, game->getViewport().height);
 
+    const Theme::Margin& margin = _style->getMargin();
+
     // Calculate local unclipped bounds.
     _bounds.set(_relativeBounds);
     if (isXPercentage())
-        _bounds.x *= parentAbsoluteBounds.width;
+        _bounds.x = _bounds.x * parentAbsoluteBounds.width + margin.left;
     if (isYPercentage())
-        _bounds.y *= parentAbsoluteBounds.height;
+        _bounds.y = _bounds.y * parentAbsoluteBounds.height + margin.top;
     if (isWidthPercentage())
         _bounds.width *= parentAbsoluteBounds.width;
     if (isHeightPercentage())
@@ -1212,7 +1214,7 @@ void Control::updateBounds()
         }
         else if ((_alignment & Control::ALIGN_VCENTER) == Control::ALIGN_VCENTER)
         {
-            _bounds.y = clipHeight * 0.5f - _bounds.height * 0.5f;
+            _bounds.y = clipHeight * 0.5f - _bounds.height * 0.5f + (margin.top - margin.bottom) * 0.5f;
         }
         else if ((_alignment & Control::ALIGN_TOP) == Control::ALIGN_TOP)
         {
@@ -1226,7 +1228,7 @@ void Control::updateBounds()
         }
         else if ((_alignment & Control::ALIGN_HCENTER) == Control::ALIGN_HCENTER)
         {
-            _bounds.x = clipWidth * 0.5f - _bounds.width * 0.5f;
+            _bounds.x = clipWidth * 0.5f - _bounds.width * 0.5f + (margin.left - margin.right) * 0.5f;
         }
         else if ((_alignment & Control::ALIGN_LEFT) == Control::ALIGN_LEFT)
         {


### PR DESCRIPTION
Fixed parent container bounds updating for non-absolute layout when child was changed.
Control's margin is taken into account for total width/height calculations.
UI modifications was tested for UI form in sample-browser and for very complex UI form in my project.
These fixes could be related to issue #1750, however, I've not tested them on the exact UI form, provided in the issue.