### PR TITLE
Support for extended ASCII codes

### DIFF
--- a/gameplay/src/Font.cpp
+++ b/gameplay/src/Font.cpp
@@ -331,7 +331,7 @@ void Font::drawText(const char* text, int x, int y, const Vector4& color, unsign
         GP_ASSERT(_batch);
         for (size_t i = startIndex; i < length; i += (size_t)iteration)
         {
-            char c = 0;
+            unsigned char c = 0;
             if (rightToLeft)
             {
                 c = cursor[i];

--- a/tools/encoder/src/EncoderArguments.cpp
+++ b/tools/encoder/src/EncoderArguments.cpp
@@ -25,6 +25,7 @@ EncoderArguments::EncoderArguments(size_t argc, const char** argv) :
     _parseError(false),
     _fontPreview(false),
     _fontFormat(Font::BITMAP),
+	_fontExtended(false),
     _textOutput(false),
     _optimizeAnimations(false),
     _animationGrouping(ANIMATIONGROUP_PROMPT),
@@ -310,6 +311,7 @@ void EncoderArguments::printUsage() const
     "  -s <sizes>\tComma-separated list of font sizes (in pixels).\n" \
     "  -p\t\tOutput font preview.\n" \
     "  -f\t\tFormat of font. -f:b (BITMAP), -f:d (DISTANCE_FIELD).\n" \
+	"  -e\tExport extra glyphs for extended ASCII. Allows accented letters." \
     "\n");
     exit(8);
 }
@@ -356,6 +358,11 @@ const char* EncoderArguments::getNodeId() const
 std::vector<unsigned int> EncoderArguments::getFontSizes() const
 {
     return _fontSizes;
+}
+
+bool EncoderArguments::getFontExtended() const
+{
+	return _fontExtended;
 }
 
 EncoderArguments::FileFormat EncoderArguments::getFileFormat() const
@@ -426,6 +433,9 @@ void EncoderArguments::readOption(const std::vector<std::string>& options, size_
             _fontFormat = Font::DISTANCE_FIELD;
         }
         break;
+	case 'e':
+		_fontExtended = true;
+		break;
     case 'g':
         if (str.compare("-groupAnimations:auto") == 0 || str.compare("-g:auto") == 0)
         {

--- a/tools/encoder/src/EncoderArguments.cpp
+++ b/tools/encoder/src/EncoderArguments.cpp
@@ -2,6 +2,7 @@
 
 #include "EncoderArguments.h"
 #include "StringUtil.h"
+#include "TTFFontEncoder.h"
 
 #ifdef WIN32
     #define PATH_MAX    _MAX_PATH
@@ -25,7 +26,8 @@ EncoderArguments::EncoderArguments(size_t argc, const char** argv) :
     _parseError(false),
     _fontPreview(false),
     _fontFormat(Font::BITMAP),
-	_fontExtended(false),
+	_fontIndexStart(GLYPH_INDEX_START),
+	_fontIndexEnd(GLYPH_INDEX_END),
     _textOutput(false),
     _optimizeAnimations(false),
     _animationGrouping(ANIMATIONGROUP_PROMPT),
@@ -311,7 +313,7 @@ void EncoderArguments::printUsage() const
     "  -s <sizes>\tComma-separated list of font sizes (in pixels).\n" \
     "  -p\t\tOutput font preview.\n" \
     "  -f\t\tFormat of font. -f:b (BITMAP), -f:d (DISTANCE_FIELD).\n" \
-	"  -e\tExport extra glyphs for extended ASCII. Allows accented letters." \
+	"  -e start,end\tSet the glyph range to be generated. Eg: -e 48,57 to export only numbers.\n" \
     "\n");
     exit(8);
 }
@@ -360,9 +362,14 @@ std::vector<unsigned int> EncoderArguments::getFontSizes() const
     return _fontSizes;
 }
 
-bool EncoderArguments::getFontExtended() const
+unsigned int EncoderArguments::getFontIndexStart() const
 {
-	return _fontExtended;
+	return _fontIndexStart;
+}
+
+unsigned int EncoderArguments::getFontIndexEnd() const
+{
+	return _fontIndexEnd;
 }
 
 EncoderArguments::FileFormat EncoderArguments::getFileFormat() const
@@ -434,7 +441,51 @@ void EncoderArguments::readOption(const std::vector<std::string>& options, size_
         }
         break;
 	case 'e':
-		_fontExtended = true;
+		{
+			std::string range;
+
+			(*index)++;
+			if (*index < options.size())
+			{
+				if (std::count(options[*index].begin(), options[*index].end(), ',') > 1)
+				{
+					LOG(1, "Error: invalid format for range argument: -e %s", options[*index].c_str());
+					_parseError = true;
+					return;
+				}
+
+				range = options[*index];
+			}
+
+			if (range.empty())
+			{
+				LOG(1, "Error: invalid format for argument: -e");
+				_parseError = true;
+				return;
+			}
+
+			// Parse comma-separated range
+			size_t middle = range.find(',');
+
+			if (middle > 0)
+			{
+				_fontIndexStart = atoi(std::string(range, 0, middle).c_str());
+				_fontIndexEnd = atoi(std::string(range, middle + 1, range.length() - 1).c_str());
+
+				if (_fontIndexStart > _fontIndexEnd)
+				{
+					LOG(1, "Error: invalid range provided: %s", range.c_str());
+					_parseError = true;
+					return;
+				}
+			}
+			else
+			{
+				LOG(1, "Error: invalid range provided: %s", range.c_str());
+				_parseError = true;
+				return;
+			}
+		}
 		break;
     case 'g':
         if (str.compare("-groupAnimations:auto") == 0 || str.compare("-g:auto") == 0)

--- a/tools/encoder/src/EncoderArguments.h
+++ b/tools/encoder/src/EncoderArguments.h
@@ -166,6 +166,8 @@ public:
 
     std::vector<unsigned int> getFontSizes() const;
 
+	bool getFontExtended() const;
+
     bool fontPreviewEnabled() const;
 
     Font::FontFormat getFontFormat() const;
@@ -218,6 +220,7 @@ private:
 
     bool _parseError;
     std::vector<unsigned int> _fontSizes;
+	bool _fontExtended;
     bool _fontPreview;
     Font::FontFormat _fontFormat;
     bool _textOutput;

--- a/tools/encoder/src/EncoderArguments.h
+++ b/tools/encoder/src/EncoderArguments.h
@@ -166,7 +166,8 @@ public:
 
     std::vector<unsigned int> getFontSizes() const;
 
-	bool getFontExtended() const;
+	unsigned int getFontIndexStart() const;
+	unsigned int getFontIndexEnd() const;
 
     bool fontPreviewEnabled() const;
 
@@ -220,7 +221,8 @@ private:
 
     bool _parseError;
     std::vector<unsigned int> _fontSizes;
-	bool _fontExtended;
+	unsigned int _fontIndexStart;
+	unsigned int _fontIndexEnd;
     bool _fontPreview;
     Font::FontFormat _fontFormat;
     bool _textOutput;

--- a/tools/encoder/src/TTFFontEncoder.cpp
+++ b/tools/encoder/src/TTFFontEncoder.cpp
@@ -111,7 +111,7 @@ unsigned char* createDistanceFields(unsigned char* img, unsigned int width, unsi
 struct FontData
 {
     // Array of glyphs for a font
-    TTFGlyph glyphArray[END_INDEX - START_INDEX];
+	TTFGlyph glyphArray[END_EXTENDED_INDEX - START_INDEX];
 
     // Stores final height of a row required to render all glyphs
     int fontSize;
@@ -135,7 +135,7 @@ struct FontData
     }
 };
  
-int writeFont(const char* inFilePath, const char* outFilePath, std::vector<unsigned int>& fontSizes, const char* id, bool fontpreview = false, Font::FontFormat fontFormat = Font::BITMAP)
+int writeFont(const char* inFilePath, const char* outFilePath, std::vector<unsigned int>& fontSizes, const char* id, bool fontpreview = false, Font::FontFormat fontFormat = Font::BITMAP, bool extended = false)
 {
     // Initialize freetype library.
     FT_Library library;
@@ -154,6 +154,9 @@ int writeFont(const char* inFilePath, const char* outFilePath, std::vector<unsig
         LOG(1, "FT_New_Face error: %d \n", error);
         return -1;
     }
+
+	unsigned int startIndex = START_INDEX;
+	unsigned int endIndex = extended ? END_EXTENDED_INDEX : END_INDEX;
 
     std::vector<FontData*> fonts;
 
@@ -195,7 +198,7 @@ int writeFont(const char* inFilePath, const char* outFilePath, std::vector<unsig
             actualfontHeight = 0;
 
             // Find the width of the image.
-            for (unsigned char ascii = START_INDEX; ascii < END_INDEX; ++ascii)
+            for (unsigned char ascii = START_INDEX; ascii < endIndex; ++ascii)
             {
                 // Load glyph image into the slot (erase previous one)
                 error = FT_Load_Char(face, ascii, loadFlags);
@@ -255,7 +258,7 @@ int writeFont(const char* inFilePath, const char* outFilePath, std::vector<unsig
 
             // Find out the squared texture size that would fit all the require font glyphs.
             i = 0;
-            for (unsigned char ascii = START_INDEX; ascii < END_INDEX; ++ascii)
+            for (unsigned char ascii = START_INDEX; ascii < endIndex; ++ascii)
             {
                 // Load glyph image into the slot (erase the previous one).
                 error = FT_Load_Char(face, ascii, loadFlags);
@@ -290,7 +293,7 @@ int writeFont(const char* inFilePath, const char* outFilePath, std::vector<unsig
                 // Move Y back to the top of the row.
                 penY = row * rowSize;
 
-                if (ascii == (END_INDEX - 1))
+                if (ascii == (endIndex - 1))
                 {
                     textureSizeFound = true;
                 }
@@ -320,7 +323,7 @@ int writeFont(const char* inFilePath, const char* outFilePath, std::vector<unsig
         penY = 0;
         row = 0;
         i = 0;
-        for (unsigned char ascii = START_INDEX; ascii < END_INDEX; ++ascii)
+        for (unsigned char ascii = START_INDEX; ascii < endIndex; ++ascii)
         {
             // Load glyph image into the slot (erase the previous one).
             error = FT_Load_Char(face, ascii, loadFlags);
@@ -415,7 +418,7 @@ int writeFont(const char* inFilePath, const char* outFilePath, std::vector<unsig
         writeString(gpbFp, "");
 
         // Glyphs.
-        unsigned int glyphSetSize = END_INDEX - START_INDEX;
+        unsigned int glyphSetSize = endIndex - startIndex;
         writeUint(gpbFp, glyphSetSize);
         for (unsigned int j = 0; j < glyphSetSize; j++)
         {

--- a/tools/encoder/src/TTFFontEncoder.h
+++ b/tools/encoder/src/TTFFontEncoder.h
@@ -2,10 +2,9 @@
 #include FT_FREETYPE_H
 #include "Font.h"
 
-#define START_INDEX			32
-#define END_INDEX			127
-#define END_EXTENDED_INDEX	255
-#define GLYPH_PADDING		4
+#define GLYPH_INDEX_START		32
+#define GLYPH_INDEX_END			255
+#define GLYPH_PADDING			4
 
 namespace gameplay
 {
@@ -29,9 +28,12 @@ public:
  * @param fontSizes List of sizes to generate for the font.
  * @param id ID string of the font in the ref table.
  * @param fontpreview True if the pgm font preview file should be written. (For debugging)
+ * @param fontFormat font format
+ * @param indexStart Start of the range of glyphs to be generated
+ * @param indexEnd End of the range of glyphs to be generated
  * 
  * @return 0 if successful, -1 if error.
  */
-int writeFont(const char* inFilePath, const char* outFilePath, std::vector<unsigned int>& fontSize, const char* id, bool fontpreview, Font::FontFormat fontFormat, bool extended);
+int writeFont(const char* inFilePath, const char* outFilePath, std::vector<unsigned int>& fontSize, const char* id, bool fontpreview, Font::FontFormat fontFormat, unsigned int indexStart, unsigned int indexEnd);
 
 }

--- a/tools/encoder/src/TTFFontEncoder.h
+++ b/tools/encoder/src/TTFFontEncoder.h
@@ -2,9 +2,10 @@
 #include FT_FREETYPE_H
 #include "Font.h"
 
-#define START_INDEX     32
-#define END_INDEX       127
-#define GLYPH_PADDING   4
+#define START_INDEX			32
+#define END_INDEX			127
+#define END_EXTENDED_INDEX	255
+#define GLYPH_PADDING		4
 
 namespace gameplay
 {
@@ -31,6 +32,6 @@ public:
  * 
  * @return 0 if successful, -1 if error.
  */
-int writeFont(const char* inFilePath, const char* outFilePath, std::vector<unsigned int>& fontSize, const char* id, bool fontpreview, Font::FontFormat fontFormat);
+int writeFont(const char* inFilePath, const char* outFilePath, std::vector<unsigned int>& fontSize, const char* id, bool fontpreview, Font::FontFormat fontFormat, bool extended);
 
 }

--- a/tools/encoder/src/main.cpp
+++ b/tools/encoder/src/main.cpp
@@ -135,7 +135,7 @@ int main(int argc, const char** argv)
                 }
             }
             std::string id = getBaseName(arguments.getFilePath());
-            writeFont(arguments.getFilePath().c_str(), arguments.getOutputFilePath().c_str(), fontSizes, id.c_str(), arguments.fontPreviewEnabled(), fontFormat);
+			writeFont(arguments.getFilePath().c_str(), arguments.getOutputFilePath().c_str(), fontSizes, id.c_str(), arguments.fontPreviewEnabled(), fontFormat, arguments.getFontExtended());
             break;
         }
     case EncoderArguments::FILEFORMAT_GPB:

--- a/tools/encoder/src/main.cpp
+++ b/tools/encoder/src/main.cpp
@@ -135,7 +135,7 @@ int main(int argc, const char** argv)
                 }
             }
             std::string id = getBaseName(arguments.getFilePath());
-			writeFont(arguments.getFilePath().c_str(), arguments.getOutputFilePath().c_str(), fontSizes, id.c_str(), arguments.fontPreviewEnabled(), fontFormat, arguments.getFontExtended());
+			writeFont(arguments.getFilePath().c_str(), arguments.getOutputFilePath().c_str(), fontSizes, id.c_str(), arguments.fontPreviewEnabled(), fontFormat, arguments.getFontIndexStart(), arguments.getFontIndexEnd());
             break;
         }
     case EncoderArguments::FILEFORMAT_GPB:


### PR DESCRIPTION
To support languages with accented letters like Spanish and Portuguese just make the encoder export the extra glyphs.

- Added -e option to export the extra glyphs.
