### PR TITLE
Mac cmake support

### DIFF
--- a/gameplay/CMakeLists.txt
+++ b/gameplay/CMakeLists.txt
@@ -1,3 +1,10 @@
+IF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(GAMEPLAY_PLATFORM_SRC
+            src/PlatformMacOSX.mm
+            )
+else(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(GAMEPLAY_PLATFORM_SRC )
+endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
 set(GAMEPLAY_SRC
     src/AbsoluteLayout.cpp
@@ -80,6 +87,7 @@ set(GAMEPLAY_SRC
     src/Gamepad.h
     src/gameplay-main-android.cpp
     src/gameplay-main-linux.cpp
+    src/gameplay-main-macosx.mm
     src/gameplay-main-windows.cpp
     src/Gesture.h
     src/HeightField.cpp
@@ -165,6 +173,7 @@ set(GAMEPLAY_SRC
     src/PlatformAndroid.cpp
     src/PlatformLinux.cpp
     src/PlatformWindows.cpp
+    ${GAMEPLAY_PLATFORM_SRC}
     src/Properties.cpp
     src/Properties.h
     src/Quaternion.cpp

--- a/gameplay/CMakeLists.txt
+++ b/gameplay/CMakeLists.txt
@@ -564,8 +564,13 @@ add_definitions(${GTK2_CFLAGS_OTHER})
 add_definitions(-D__linux__)
 ENDIF(CMAKE_SYSTEM_NAME MATCHES "Linux")
 
-add_definitions(-std=c++11)
-add_definitions(-lstdc++)
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    # using Clang
+    add_definitions(-std=c++11 -stdlib=libc++)
+else()
+    add_definitions(-std=c++11)
+    add_definitions(-lstdc++)
+endif()
 
 add_library(gameplay STATIC
     ${GAMEPLAY_SRC}

--- a/samples/BuildHelpers.CMakeLists.txt
+++ b/samples/BuildHelpers.CMakeLists.txt
@@ -62,22 +62,23 @@ macro(MAKE_ABSOLUTE RESULT REL_PATH)
     endforeach()
 endmacro()
 
-macro(COPY_RES_MAC RESULT BASE_SRC_PATH REL_PATH)
+# Build a list of resource files matching a list of regular expression within a given path
+# and mark their correct Mac OS X destination, keeping the relative position to a base path
+#   RESULT name of the global variable into which the result is built
+#   BASE_SRC_PATH the base path under which the structure is replicated in the bundle
+#   REL_PATH a pattern to be matched and searched recursively.
+macro(COPY_RES_MAC RESULT BASE_SRC_PATH)
 	set(${RESULT})
-	MESSAGE("COPY_RES_MAC with base ${BASE_SRC_PATH} and rel ${REL_PATH}")
-	#foreach(PATTERN ${ARGN} )
-            file(GLOB_RECURSE XX RELATIVE ${BASE_SRC_PATH} ${BASE_SRC_PATH}/${REL_PATH}/${PATTERN})
-            MESSAGE("XX is ${XX}")
+	foreach(PATTERN ${ARGN} )
+            file(GLOB_RECURSE XX RELATIVE ${BASE_SRC_PATH} ${BASE_SRC_PATH}/${PATTERN})
             foreach(FNAME ${XX})
-                list(APPEND ${RESULT} ${BASE_SRC_PATH}/${XX})
-                MESSAGE("Working on ${FNAME}")
-                get_filename_component(YY ${FNAME} DIRECTORY )
-                MESSAGE("Directory is ${YY} for ${BASE_SRC_PATH}/${FNAME}")
-                SET_SOURCE_FILES_PROPERTIES(
+                list(APPEND ${RESULT} ${BASE_SRC_PATH}/${FNAME})
+                get_filename_component(DIR ${FNAME} DIRECTORY )
+                set_source_files_properties(
                             ${BASE_SRC_PATH}/${FNAME}
                             PROPERTIES
-                            MACOSX_PACKAGE_LOCATION Resources/${YY}
+                            MACOSX_PACKAGE_LOCATION Resources/${DIR}
                     )
             endforeach()
-    #endforeach()
+    endforeach()
 endmacro()

--- a/samples/BuildHelpers.CMakeLists.txt
+++ b/samples/BuildHelpers.CMakeLists.txt
@@ -49,3 +49,35 @@ macro(COPY_RES_EXTRA GAME_NAME REL_DIR)
     COPY_RES_FILES( ${GAME_NAME} ${GAME_NAME}_EXTRA_RES ${REL_DIR} "${SRC_FILES}" )
     add_dependencies( ${GAME_NAME}_ASSETS ${GAME_NAME}_EXTRA_RES )
 endmacro()
+
+# Build a list of file matching a list of regular expression within a given path
+#   RESULT name of the global variable into which the result is built
+#   REL_PATH the path under which the files are to be found
+#   ARGN list of patterns
+macro(MAKE_ABSOLUTE RESULT REL_PATH)
+    set(${RESULT})
+    foreach(SRC_FILE ${ARGN} )
+        file(GLOB XX ${REL_PATH}/${SRC_FILE})
+        list(APPEND ${RESULT} ${XX})
+    endforeach()
+endmacro()
+
+macro(COPY_RES_MAC RESULT BASE_SRC_PATH REL_PATH)
+	set(${RESULT})
+	MESSAGE("COPY_RES_MAC with base ${BASE_SRC_PATH} and rel ${REL_PATH}")
+	#foreach(PATTERN ${ARGN} )
+            file(GLOB_RECURSE XX RELATIVE ${BASE_SRC_PATH} ${BASE_SRC_PATH}/${REL_PATH}/${PATTERN})
+            MESSAGE("XX is ${XX}")
+            foreach(FNAME ${XX})
+                list(APPEND ${RESULT} ${BASE_SRC_PATH}/${XX})
+                MESSAGE("Working on ${FNAME}")
+                get_filename_component(YY ${FNAME} DIRECTORY )
+                MESSAGE("Directory is ${YY} for ${BASE_SRC_PATH}/${FNAME}")
+                SET_SOURCE_FILES_PROPERTIES(
+                            ${BASE_SRC_PATH}/${FNAME}
+                            PROPERTIES
+                            MACOSX_PACKAGE_LOCATION Resources/${YY}
+                    )
+            endforeach()
+    #endforeach()
+endmacro()

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -36,7 +36,6 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
             ${IOKIT_LIBRARY}
             "-framework Foundation"
             "-framework Cocoa")
-    SET(EXEC_TYPE MACOSX_BUNDLE)
     link_directories(${CMAKE_SOURCE_DIR}/external-deps/lib/macosx/x86_64)
     set(GAMEPLAY_LIBRARIES
             stdc++

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,33 +1,77 @@
 include(BuildHelpers.CMakeLists.txt)
 
-include_directories( 
-    ${CMAKE_SOURCE_DIR}/gameplay/src
-    ${CMAKE_SOURCE_DIR}/external-deps/include
+include_directories(
+        ${CMAKE_SOURCE_DIR}/gameplay/src
+        ${CMAKE_SOURCE_DIR}/external-deps/include
 )
 
-add_definitions(-D__linux__)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    find_package(OpenGL REQUIRED)
+    FIND_LIBRARY(AGL_LIBRARY AGL)
+    FIND_LIBRARY(APP_SERVICES_LIBRARY ApplicationServices )
+    FIND_LIBRARY(ATBOX_LIBRARY AudioToolbox)
+    FIND_LIBRARY(CARBON_LIBRARY Carbon)
+    FIND_LIBRARY(CAUDIO_LIBRARY CoreAudio)
+    FIND_LIBRARY(COREVIDEO_LIBRARY CoreVideo)
+    FIND_LIBRARY(CFOUNDATION_LIBRARY CoreFoundation)
+    FIND_LIBRARY(CSERVICES_LIBRARY CoreServices)
+    FIND_LIBRARY(OPENGL_LIBRARY OpenGL)
+    FIND_LIBRARY(QUICKTIME_LIBRARY QuickTime )
+    FIND_LIBRARY(IOKIT_LIBRARY IOKit )
+    FIND_LIBRARY(AVF_LIBRARY AVFoundation)
+    FIND_LIBRARY(OAL_LIBRARY OpenAL)
+    FIND_LIBRARY(GKIT_LIBRARY GameKit)
+    SET(FRAMEWORK_LIBRS
+            ${AGL_LIBRARY}
+            ${APP_SERVICES_LIBRARY}
+            ${ATBOX_LIBRARY}
+            ${CARBON_LIBRARY}
+            ${CAUDIO_LIBRARY}
+            ${COREVIDEO_LIBRARY}
+            ${CFOUNDATION_LIBRARY}
+            ${CSERVICES_LIBRARY}
+            ${OAL_LIBRARY}
+            ${OPENGL_LIBRARIES}
+            ${GKIT_LIBRARY}
+            ${IOKIT_LIBRARY}
+            "-framework Foundation"
+            "-framework Cocoa")
+    SET(EXEC_TYPE MACOSX_BUNDLE)
+    link_directories(${CMAKE_SOURCE_DIR}/external-deps/lib/macosx/x86_64)
+    set(GAMEPLAY_LIBRARIES
+            stdc++
+            gameplay
+            gameplay-deps
+            m
+            dl
+            pthread
+            ${FRAMEWORK_LIBRS}
+            )
+ELSE(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    add_definitions(-D__linux__)
 
-IF(ARCH_DIR STREQUAL "x64")
-    link_directories(${CMAKE_SOURCE_DIR}/external-deps/lib/linux/x86_64)
-ELSE()
-    link_directories(${CMAKE_SOURCE_DIR}/external-deps/lib/linux/x86)
-ENDIF(ARCH_DIR STREQUAL "x64")
+    IF(ARCH_DIR STREQUAL "x64")
+        link_directories(${CMAKE_SOURCE_DIR}/external-deps/lib/linux/x86_64)
+    ELSE()
+        link_directories(${CMAKE_SOURCE_DIR}/external-deps/lib/linux/x86)
+    ENDIF(ARCH_DIR STREQUAL "x64")
 
 
-set(GAMEPLAY_LIBRARIES
-    stdc++
-    gameplay
-    gameplay-deps
-    m
-    GL
-    rt
-    dl
-    X11
-    pthread
-    gtk-x11-2.0
-    glib-2.0
-    gobject-2.0
-) 
+    set(GAMEPLAY_LIBRARIES
+            stdc++
+            gameplay
+            gameplay-deps
+            m
+            GL
+            rt
+            dl
+            X11
+            pthread
+            gtk-x11-2.0
+            glib-2.0
+            gobject-2.0
+            )
+ENDIF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
 add_definitions(-std=c++11)
 

--- a/samples/browser/CMakeLists.txt
+++ b/samples/browser/CMakeLists.txt
@@ -55,24 +55,53 @@ set(GAME_SRC
     src/WaterSample.h
 )
 
-add_executable(${GAME_NAME}
-    ${GAME_SRC}
-)
+
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    MESSAGE("Game name is ${GAME_NAME}")
+    COPY_RES_MAC(GAME_RES ${CMAKE_SOURCE_DIR}/samples/browser res/*)
+    COPY_RES_MAC(GAMEPLAY_RES ${CMAKE_SOURCE_DIR}/gameplay
+            res/shaders/* res/ui/* res/logo_powered_white.png)
+    set(Apple_Resources
+            ${GAME_RES}
+            ${GAMEPLAY_RES}
+            game.config)
+    SET(EXEC_TYPE MACOSX_BUNDLE)
+
+    SET_SOURCE_FILES_PROPERTIES(
+            game.config
+            PROPERTIES
+            MACOSX_PACKAGE_LOCATION Resources
+    )
+    set( MACOSX_BUNDLE_INFO_STRING "\"${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}\",\nCopyright 2016 gameplay3d contributors" )
+    set( MACOSX_BUNDLE_SHORT_VERSION_STRING "${VERSION_MAJOR}.${VERSION_MINOR}" )
+    set( MACOSX_BUNDLE_LONG_VERSION_STRING "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}" )
+    set( MACOSX_BUNDLE_BUNDLE_VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}" )
+    set( MACOSX_BUNDLE_COPYRIGHT "(C) gameplay3d contributors" )
+    set( PLIST_TEMPLATE ${GAME_NAME}-macosx.plist )
+endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+
+add_executable(${GAME_NAME} ${EXEC_TYPE}
+        ${GAME_SRC}
+        ${Apple_Resources}
+        )
 
 target_link_libraries(${GAME_NAME} ${GAMEPLAY_LIBRARIES})
+
 
 set_target_properties(${GAME_NAME} PROPERTIES
     OUTPUT_NAME "${GAME_NAME}"
     CLEAN_DIRECT_OUTPUT 1
 )
 
-source_group(res FILES ${GAME_RES} ${GAMEPLAY_RES} ${GAMEPLAY_RES_SHADERS} ${GAMEPLAY_RES_UI})
-source_group(src FILES ${GAME_SRC})
+if(!${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
-COPY_RES( ${GAME_NAME} )
-COPY_RES_EXTRA( ${GAME_NAME} ${CMAKE_SOURCE_DIR}/gameplay
-    res/logo_powered_white.png 
-    res/shaders/*
-    res/ui/*
-)
+    source_group(res FILES ${GAME_RES} ${GAMEPLAY_RES} ${GAMEPLAY_RES_SHADERS} ${GAMEPLAY_RES_UI})
+    source_group(src FILES ${GAME_SRC})
 
+    COPY_RES( ${GAME_NAME} )
+    COPY_RES_EXTRA( ${GAME_NAME} ${CMAKE_SOURCE_DIR}/gameplay
+            res/logo_powered_white.png
+            res/shaders/*
+            res/ui/*
+            )
+endif(!${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/samples/character/CMakeLists.txt
+++ b/samples/character/CMakeLists.txt
@@ -5,26 +5,51 @@ set(GAME_SRC
     src/CharacterGame.h
 )
 
-add_executable(${GAME_NAME}
-    ${GAME_SRC}
-)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    COPY_RES_MAC(GAME_RES ${CMAKE_SOURCE_DIR}/samples/character res/*)
+    COPY_RES_MAC(GAMEPLAY_RES ${CMAKE_SOURCE_DIR}/gameplay
+            res/shaders/* res/ui/* res/logo_powered_white.png)
+    set(Apple_Resources
+            ${GAME_RES}
+            ${GAMEPLAY_RES}
+            game.config)
+    SET(EXEC_TYPE MACOSX_BUNDLE)
+
+    SET_SOURCE_FILES_PROPERTIES(
+            game.config
+            PROPERTIES
+            MACOSX_PACKAGE_LOCATION Resources
+    )
+    set( MACOSX_BUNDLE_INFO_STRING "\"${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}\",\nCopyright 2016 gameplay3d contributors" )
+    set( MACOSX_BUNDLE_SHORT_VERSION_STRING "${VERSION_MAJOR}.${VERSION_MINOR}" )
+    set( MACOSX_BUNDLE_LONG_VERSION_STRING "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}" )
+    set( MACOSX_BUNDLE_BUNDLE_VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}" )
+    set( MACOSX_BUNDLE_COPYRIGHT "(C) gameplay3d contributors" )
+    set( PLIST_TEMPLATE sample-racer-macosx.plist )
+endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+
+add_executable(${GAME_NAME} ${EXEC_TYPE}
+        ${GAME_SRC} ${Apple_Resources}
+        )
 
 target_link_libraries(${GAME_NAME} ${GAMEPLAY_LIBRARIES})
 
-set_target_properties(${GAME_NAME} PROPERTIES
-    OUTPUT_NAME "${GAME_NAME}"
-    CLEAN_DIRECT_OUTPUT 1
-)
+if(!${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
-source_group(res FILES ${GAME_RES} ${GAMEPLAY_RES} ${GAMEPLAY_RES_SHADERS} ${GAMEPLAY_RES_UI})
-source_group(src FILES ${GAME_SRC})
+    set_target_properties(${GAME_NAME} PROPERTIES
+            OUTPUT_NAME "${GAME_NAME}"
+            CLEAN_DIRECT_OUTPUT 1
+            )
 
-COPY_RES( ${GAME_NAME} )
-COPY_RES_EXTRA( ${GAME_NAME} ${CMAKE_SOURCE_DIR}/gameplay
-    res/logo_powered_white.png 
-    res/shaders/*
-    res/ui/*
-)
+    source_group(res FILES ${GAME_RES} ${GAMEPLAY_RES} ${GAMEPLAY_RES_SHADERS} ${GAMEPLAY_RES_UI})
+    source_group(src FILES ${GAME_SRC})
 
+    COPY_RES( ${GAME_NAME} )
+    COPY_RES_EXTRA( ${GAME_NAME} ${CMAKE_SOURCE_DIR}/gameplay
+            res/logo_powered_white.png
+            res/shaders/*
+            res/ui/*
+            )
+endif(!${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 # Just use the PNG config file (most compatible)
 configure_file( game.dxt.config game.config COPYONLY )

--- a/samples/racer/CMakeLists.txt
+++ b/samples/racer/CMakeLists.txt
@@ -16,38 +16,16 @@ source_group(res FILES ${GAME_RES} ${GAMEPLAY_RES} ${GAMEPLAY_RES_SHADERS} ${GAM
 source_group(src FILES ${GAME_SRC})
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    MAKE_ABSOLUTE(GAMEPLAY_RES_SHADERS  ${CMAKE_SOURCE_DIR}/gameplay
-            res/shaders/*)
-    MAKE_ABSOLUTE(GAMEPLAY_RES_UI  ${CMAKE_SOURCE_DIR}/gameplay
-            res/ui/*)
-    MESSAGE("GP Shaders ${GAMEPLAY_RES_SHADERS}")
-#    include(BundleUtilities)
-#    SET(GAME_RES res/png/car.png)
     COPY_RES_MAC(GAME_RES ${CMAKE_SOURCE_DIR}/samples/racer res/*)
-    message("Resources are ${GAME_RES} !!!")
+    COPY_RES_MAC(GAMEPLAY_RES ${CMAKE_SOURCE_DIR}/gameplay
+            res/shaders/* res/ui/* res/logo_powered_white.png)
     set(Apple_Resources
             ../../gameplay/res/logo_powered_white.png
             ${GAME_RES}
             ${GAMEPLAY_RES}
-            ${GAMEPLAY_RES_SHADERS}
-            ${GAMEPLAY_RES_UI}
             game.config)
     SET(EXEC_TYPE MACOSX_BUNDLE)
-    SET_SOURCE_FILES_PROPERTIES(
-            ../../gameplay/res/logo_powered_white.png
-            PROPERTIES
-            MACOSX_PACKAGE_LOCATION Resources/res
-    )
-    SET_SOURCE_FILES_PROPERTIES(
-            ${GAMEPLAY_RES_SHADERS}
-            PROPERTIES
-            MACOSX_PACKAGE_LOCATION Resources/res/shaders
-    )
-    SET_SOURCE_FILES_PROPERTIES(
-            ${GAMEPLAY_RES_UI}
-            PROPERTIES
-            MACOSX_PACKAGE_LOCATION Resources/res/ui
-    )
+
     SET_SOURCE_FILES_PROPERTIES(
             game.config
             PROPERTIES
@@ -59,7 +37,6 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set( MACOSX_BUNDLE_BUNDLE_VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}" )
     set( MACOSX_BUNDLE_COPYRIGHT "(C) gameplay3d contributors" )
     set( PLIST_TEMPLATE sample-racer-macosx.plist )
-    configure_file( game.png.config game.config COPYONLY )
 endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
 add_executable(${GAME_NAME} ${EXEC_TYPE}
@@ -68,19 +45,7 @@ add_executable(${GAME_NAME} ${EXEC_TYPE}
         )
 target_link_libraries(${GAME_NAME} ${GAMEPLAY_LIBRARIES})
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    #    SET_TARGET_PROPERTIES( ${GAME_NAME}
-    #            PROPERTIES MACOSX_BUNDLE_INFO_PLIST "${CMAKE_SOURCE_DIR}/samples/racer/${PLIST_TEMPLATE}" )
-    #    install(TARGETS ${GAME_NAME}
-    #            RUNTIME DESTINATION bin
-    #            BUNDLE DESTINATION bundle
-    #            )
-#    GET_BUNDLE_AND_EXECUTABLE(${GAME_NAME} BUNDLE_NAME EXEC_NAME VALID_TAG)
-#    message("Bundle name is ${BUNDLE_NAME} valid ${VALID_TAG}")
-#    GET_DOTAPP_DIR(${GAME_NAME} DIR_NAME)
-#    message(".app dirr name is ${DIR_NAME}")
-    configure_file( game.png.config game.config COPYONLY )
-else(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+if(!${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
 
     COPY_RES( ${GAME_NAME} )
@@ -90,6 +55,6 @@ else(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
             res/ui/*
             )
 
-    # Just use the PNG config file (most compatible)
-    configure_file( game.png.config game.config COPYONLY )
-endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+endif(!${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+# Just use the PNG config file (most compatible)
+configure_file( game.png.config game.config COPYONLY )

--- a/samples/racer/CMakeLists.txt
+++ b/samples/racer/CMakeLists.txt
@@ -1,30 +1,95 @@
 set(GAME_NAME sample-racer)
 
 set(GAME_SRC
-    src/RacerGame.cpp
-    src/RacerGame.h
-)
+        src/RacerGame.cpp
+        src/RacerGame.h
+        )
 
-add_executable(${GAME_NAME}
-    ${GAME_SRC}
-)
-
-target_link_libraries(${GAME_NAME} ${GAMEPLAY_LIBRARIES})
-
-set_target_properties(${GAME_NAME} PROPERTIES
-    OUTPUT_NAME "${GAME_NAME}"
-    CLEAN_DIRECT_OUTPUT 1
-)
+if(!${APPLE})
+    set_target_properties(${GAME_NAME} PROPERTIES
+            OUTPUT_NAME "${GAME_NAME}"
+            CLEAN_DIRECT_OUTPUT 1
+            )
+endif(!${APPLE})
 
 source_group(res FILES ${GAME_RES} ${GAMEPLAY_RES} ${GAMEPLAY_RES_SHADERS} ${GAMEPLAY_RES_UI})
 source_group(src FILES ${GAME_SRC})
 
-COPY_RES( ${GAME_NAME} )
-COPY_RES_EXTRA( ${GAME_NAME} ${CMAKE_SOURCE_DIR}/gameplay
-    res/logo_powered_white.png 
-    res/shaders/*
-    res/ui/*
-)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    MAKE_ABSOLUTE(GAMEPLAY_RES_SHADERS  ${CMAKE_SOURCE_DIR}/gameplay
+            res/shaders/*)
+    MAKE_ABSOLUTE(GAMEPLAY_RES_UI  ${CMAKE_SOURCE_DIR}/gameplay
+            res/ui/*)
+    MESSAGE("GP Shaders ${GAMEPLAY_RES_SHADERS}")
+#    include(BundleUtilities)
+#    SET(GAME_RES res/png/car.png)
+    COPY_RES_MAC(GAME_RES ${CMAKE_SOURCE_DIR}/samples/racer res/*)
+    message("Resources are ${GAME_RES} !!!")
+    set(Apple_Resources
+            ../../gameplay/res/logo_powered_white.png
+            ${GAME_RES}
+            ${GAMEPLAY_RES}
+            ${GAMEPLAY_RES_SHADERS}
+            ${GAMEPLAY_RES_UI}
+            game.config)
+    SET(EXEC_TYPE MACOSX_BUNDLE)
+    SET_SOURCE_FILES_PROPERTIES(
+            ../../gameplay/res/logo_powered_white.png
+            PROPERTIES
+            MACOSX_PACKAGE_LOCATION Resources/res
+    )
+    SET_SOURCE_FILES_PROPERTIES(
+            ${GAMEPLAY_RES_SHADERS}
+            PROPERTIES
+            MACOSX_PACKAGE_LOCATION Resources/res/shaders
+    )
+    SET_SOURCE_FILES_PROPERTIES(
+            ${GAMEPLAY_RES_UI}
+            PROPERTIES
+            MACOSX_PACKAGE_LOCATION Resources/res/ui
+    )
+    SET_SOURCE_FILES_PROPERTIES(
+            game.config
+            PROPERTIES
+            MACOSX_PACKAGE_LOCATION Resources
+    )
+    set( MACOSX_BUNDLE_INFO_STRING "\"${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}\",\nCopyright 2016 gameplay3d contributors" )
+    set( MACOSX_BUNDLE_SHORT_VERSION_STRING "${VERSION_MAJOR}.${VERSION_MINOR}" )
+    set( MACOSX_BUNDLE_LONG_VERSION_STRING "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}" )
+    set( MACOSX_BUNDLE_BUNDLE_VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}" )
+    set( MACOSX_BUNDLE_COPYRIGHT "(C) gameplay3d contributors" )
+    set( PLIST_TEMPLATE sample-racer-macosx.plist )
+    configure_file( game.png.config game.config COPYONLY )
+endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
-# Just use the PNG config file (most compatible)
-configure_file( game.png.config game.config COPYONLY )
+add_executable(${GAME_NAME} ${EXEC_TYPE}
+        ${GAME_SRC}
+        ${Apple_Resources}
+        )
+target_link_libraries(${GAME_NAME} ${GAMEPLAY_LIBRARIES})
+
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    #    SET_TARGET_PROPERTIES( ${GAME_NAME}
+    #            PROPERTIES MACOSX_BUNDLE_INFO_PLIST "${CMAKE_SOURCE_DIR}/samples/racer/${PLIST_TEMPLATE}" )
+    #    install(TARGETS ${GAME_NAME}
+    #            RUNTIME DESTINATION bin
+    #            BUNDLE DESTINATION bundle
+    #            )
+#    GET_BUNDLE_AND_EXECUTABLE(${GAME_NAME} BUNDLE_NAME EXEC_NAME VALID_TAG)
+#    message("Bundle name is ${BUNDLE_NAME} valid ${VALID_TAG}")
+#    GET_DOTAPP_DIR(${GAME_NAME} DIR_NAME)
+#    message(".app dirr name is ${DIR_NAME}")
+    configure_file( game.png.config game.config COPYONLY )
+else(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+
+
+    COPY_RES( ${GAME_NAME} )
+    COPY_RES_EXTRA( ${GAME_NAME} ${CMAKE_SOURCE_DIR}/gameplay
+            res/logo_powered_white.png
+            res/shaders/*
+            res/ui/*
+            )
+
+    # Just use the PNG config file (most compatible)
+    configure_file( game.png.config game.config COPYONLY )
+endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/samples/racer/CMakeLists.txt
+++ b/samples/racer/CMakeLists.txt
@@ -20,7 +20,6 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     COPY_RES_MAC(GAMEPLAY_RES ${CMAKE_SOURCE_DIR}/gameplay
             res/shaders/* res/ui/* res/logo_powered_white.png)
     set(Apple_Resources
-            ../../gameplay/res/logo_powered_white.png
             ${GAME_RES}
             ${GAMEPLAY_RES}
             game.config)

--- a/samples/spaceship/CMakeLists.txt
+++ b/samples/spaceship/CMakeLists.txt
@@ -5,23 +5,50 @@ set(GAME_SRC
     src/SpaceshipGame.h
 )
 
-add_executable(${GAME_NAME}
-    ${GAME_SRC}
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    COPY_RES_MAC(GAME_RES ${CMAKE_SOURCE_DIR}/samples/spaceship res/*)
+    COPY_RES_MAC(GAMEPLAY_RES ${CMAKE_SOURCE_DIR}/gameplay
+            res/shaders/* res/ui/* res/logo_powered_white.png)
+    set(Apple_Resources
+            ../../gameplay/res/logo_powered_white.png
+            ${GAME_RES}
+            ${GAMEPLAY_RES}
+            game.config)
+    SET(EXEC_TYPE MACOSX_BUNDLE)
+
+    SET_SOURCE_FILES_PROPERTIES(
+            game.config
+            PROPERTIES
+            MACOSX_PACKAGE_LOCATION Resources
+    )
+    set( MACOSX_BUNDLE_INFO_STRING "\"${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}\",\nCopyright 2016 gameplay3d contributors" )
+    set( MACOSX_BUNDLE_SHORT_VERSION_STRING "${VERSION_MAJOR}.${VERSION_MINOR}" )
+    set( MACOSX_BUNDLE_LONG_VERSION_STRING "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}" )
+    set( MACOSX_BUNDLE_BUNDLE_VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}" )
+    set( MACOSX_BUNDLE_COPYRIGHT "(C) gameplay3d contributors" )
+    set( PLIST_TEMPLATE sample-racer-macosx.plist )
+endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+
+add_executable(${GAME_NAME} ${EXEC_TYPE}
+    ${GAME_SRC} ${Apple_Resources}
 )
 
 target_link_libraries(${GAME_NAME} ${GAMEPLAY_LIBRARIES})
 
-set_target_properties(${GAME_NAME} PROPERTIES
-    OUTPUT_NAME "${GAME_NAME}"
-    CLEAN_DIRECT_OUTPUT 1
-)
+if(!${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
-source_group(res FILES ${GAME_RES} ${GAMEPLAY_RES} ${GAMEPLAY_RES_SHADERS} ${GAMEPLAY_RES_UI})
-source_group(src FILES ${GAME_SRC})
+    set_target_properties(${GAME_NAME} PROPERTIES
+            OUTPUT_NAME "${GAME_NAME}"
+            CLEAN_DIRECT_OUTPUT 1
+            )
 
-COPY_RES( ${GAME_NAME} )
-COPY_RES_EXTRA( ${GAME_NAME} ${CMAKE_SOURCE_DIR}/gameplay
-    res/logo_powered_white.png 
-    res/shaders/*
-    res/ui/*
-)
+    source_group(res FILES ${GAME_RES} ${GAMEPLAY_RES} ${GAMEPLAY_RES_SHADERS} ${GAMEPLAY_RES_UI})
+    source_group(src FILES ${GAME_SRC})
+
+    COPY_RES( ${GAME_NAME} )
+    COPY_RES_EXTRA( ${GAME_NAME} ${CMAKE_SOURCE_DIR}/gameplay
+            res/logo_powered_white.png
+            res/shaders/*
+            res/ui/*
+            )
+endif(!${CMAKE_SYSTEM_NAME} MATCHES "Darwin")


### PR DESCRIPTION
I added support to build the library and the samples using CMake.
Among other things, this allows to checkout the code with CLion and compile it directly out of the box.
I have tried to make sure that my modifications result in no changes if not used under Mac OS X but have no way to test all cases.