### PR TITLE
Allow file saving on iOS

### DIFF
--- a/gameplay/src/FileSystem.cpp
+++ b/gameplay/src/FileSystem.cpp
@@ -29,7 +29,7 @@ extern AAssetManager* __assetManager;
 
 namespace gameplay
 {
-
+#ifndef WIN32
 #include <unistd.h>
 
 static void makepath(std::string path, int mode)
@@ -66,6 +66,7 @@ static void makepath(std::string path, int mode)
     }
     return;
 }
+#endif
 #ifdef __ANDROID__
 
 /**
@@ -422,6 +423,7 @@ Stream* FileSystem::open(const char* path, size_t streamMode, bool external)
 #else
     std::string fullPath;
     getFullPath(path, fullPath, useExternal);
+#ifndef WIN32
     if(useExternal && __externalPath.compare(__resourcePath) != 0) {
         size_t index = fullPath.rfind('/');
         if(index != std::string::npos) {
@@ -431,6 +433,7 @@ Stream* FileSystem::open(const char* path, size_t streamMode, bool external)
                 makepath(directoryPath, 0777);
         }
     }
+#endif
     FileStream* stream = FileStream::create(fullPath.c_str(), modeStr);
     return stream;
 #endif

--- a/gameplay/src/FileSystem.h
+++ b/gameplay/src/FileSystem.h
@@ -52,6 +52,11 @@ public:
      * @param path The path to the root of the resources folder.
      */
     static void setResourcePath(const char* path);
+    
+    
+    static void setExternalPath(const char* path);
+    
+    static const char* getExternalPath();
 
     /**
      * Returns the currently set resource path.
@@ -144,7 +149,7 @@ public:
      * 
      * @return <code>true</code> if the file exists; <code>false</code> otherwise.
      */
-    static bool fileExists(const char* filePath);
+    static bool fileExists(const char* filePath, bool external = false);
 
     /**
      * Opens a byte stream for the given resource path.
@@ -160,7 +165,7 @@ public:
      *
      * @script{ignore}
      */
-    static Stream* open(const char* path, size_t streamMode = READ);
+    static Stream* open(const char* path, size_t streamMode = READ, bool external = false);
 
     /**
      * Opens the specified file.
@@ -190,7 +195,7 @@ public:
      * @return A newly allocated (NULL-terminated) character array containing the
      *      contents of the file, or NULL if the file could not be read.
      */
-    static char* readAll(const char* filePath, int* fileSize = NULL);
+    static char* readAll(const char* filePath, int* fileSize = NULL, bool external = false);
 
     /**
      * Determines if the file path is an absolute path for the current platform.

--- a/gameplay/src/PlatformiOS.mm
+++ b/gameplay/src/PlatformiOS.mm
@@ -204,7 +204,11 @@ int getUnicode(int key);
         
         // Set the resource path and initalize the game
         NSString* bundlePath = [[[NSBundle mainBundle] bundlePath] stringByAppendingString:@"/"];
-        FileSystem::setResourcePath([bundlePath fileSystemRepresentation]); 
+        FileSystem::setResourcePath([bundlePath fileSystemRepresentation]);
+        
+        NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+        NSString *documentsPath = [[paths objectAtIndex:0] stringByAppendingString:@"/"];
+        FileSystem::setExternalPath([documentsPath fileSystemRepresentation]);
     }
     return self;
 }


### PR DESCRIPTION
This is an update based on a forum post about not being able to save on iOS. A user (whose identity I couldn't find) posted a fix here:
https://groups.google.com/d/msg/gameplay3d-developers/Ts73-qFtyCI/ikI_hjSsEAAJ

This worked liked a charm except it had the side effect of creating compile errors in Windows. I added some preprocessor checks to make those go away so now this iOS saving fix won't break you on Windows anymore.

Tested in OSX, Ubuntu and Windows 10. Built to iOS and Android.