### PR TITLE
qtcreator project update

### DIFF
--- a/gameplay-all.pro
+++ b/gameplay-all.pro
@@ -1,0 +1,11 @@
+QMAKE_CLEAN += $$DESTDIR/$$TARGET
+
+TEMPLATE = subdirs
+
+CONFIG = ordered
+
+SUBDIRS += \
+    gameplay/gameplay.pro \
+    gameplay-app/gameplay-app.pro \
+    gameplay-editor/gameplay-editor.pro \
+

--- a/gameplay-app/gameplay-app.pro
+++ b/gameplay-app/gameplay-app.pro
@@ -5,6 +5,8 @@ CONFIG += c++11
 CONFIG -= qt
 CONFIG(debug, debug|release): DEFINES += _DEBUG
 
+DESTDIR = $$PWD/../build/bin
+
 SOURCES += src/App.cpp
 
 HEADERS += src/App.h
@@ -17,8 +19,8 @@ win32 {
     DEFINES += VK_USE_PLATFORM_WIN32_KHR
     SOURCES += src/main-windows.cpp
     INCLUDEPATH += $$(VULKAN_SDK)/Include
-    CONFIG(debug, debug|release): LIBS += -L$$PWD/../build/gameplay/Debug/debug/ -lgameplay
-    CONFIG(release, debug|release): LIBS += -L$$PWD/../build/gameplay/Release/release/ -lgameplay
+    CONFIG(debug, debug|release): LIBS += -L$$PWD/../build/lib/ -lgameplay_d
+    CONFIG(release, debug|release): LIBS += -L$$PWD/../build/lib/ -lgameplay
     CONFIG(debug, debug|release): LIBS += -L$$PWD/../external-deps/lib/windows/x86_64/Debug/ -lgameplay-deps
     CONFIG(release, debug|release): LIBS += -L$$PWD/../external-deps/lib/windows/x86_64/Release/ -lgameplay-deps
     LIBS += -lkernel32 -luser32 -lgdi32 -lwinspool -lcomdlg32 -ladvapi32 -lshell32 -lole32 -loleaut32 -luuid -lodbc32 -lodbccp32 -limm32 -limagehlp -lversion -lwinmm -lxinput
@@ -32,6 +34,8 @@ win32 {
 }
 
 linux {
+    CONFIG(debug, debug|release): PRE_TARGETDEPS += $$PWD/../build/lib/libgameplay_d.a
+    CONFIG(release, debug|release):PRE_TARGETDEPS += $$PWD/../build/lib/libgameplay.a
     DEFINES += SDL_VIDEO_DRIVER_X11
     DEFINES += VK_USE_PLATFORM_XLIB_KHR
     SOURCES += src/main-linux.cpp
@@ -49,10 +53,10 @@ linux {
     INCLUDEPATH += /usr/include/pixman-1
     INCLUDEPATH += /usr/include/libpng12
     INCLUDEPATH += /usr/include/harfbuzz
-    CONFIG(debug, debug|release): LIBS += -L$$PWD/../build/gameplay/Debug/ -lgameplay
-    CONFIG(release, debug|release): LIBS += -L$$PWD/../build/gameplay/Release/ -lgameplay
+    CONFIG(debug, debug|release): LIBS += -L$$PWD/../build/lib/ -lgameplay_d
+    CONFIG(release, debug|release): LIBS += -L$$PWD/../build/lib/ -lgameplay
     LIBS += -L$$PWD/../external-deps/lib/linux/x86_64/ -lgameplay-deps
-    LIBS += -lm -lrt -ldl -lX11 -lpthread -lgtk-x11-2.0 -lglib-2.0 -lgobject-2.0 -lxcb -lsndio
+    LIBS += -lm -lrt -ldl -lX11 -lpthread -lglib-2.0 -lgobject-2.0 -lxcb -lsndio
     LIBS += -L$$(VULKAN_SDK)/lib/ -lvulkan
     QMAKE_CXXFLAGS += -lstdc++ -pthread -w
 }
@@ -61,8 +65,8 @@ macx {
     DEFINES += VK_USE_PLATFORM_MACOS_MVK
     INCLUDEPATH += $$(HOME)/vulkansdk-macos-1.0.69.0/macOS/include
     SOURCES += src/main-macos.mm
-    CONFIG(debug, debug|release): LIBS += -L$$PWD/../build/gameplay/Debug/ -lgameplay
-    CONFIG(release, debug|release):LIBS += -L$$PWD/../build/gameplay/Release/ -lgameplay
+    CONFIG(debug, debug|release): LIBS += -L$$PWD/../build/lib/ -lgameplay_d
+    CONFIG(release, debug|release):LIBS += -L$$PWD/../build/lib/ -lgameplay
     LIBS += -L$$PWD/../external-deps/lib/macos/x86_64/ -lgameplay-deps
     LIBS += -L/usr/lib -liconv
     LIBS += -F$$(HOME)/vulkansdk-macos-1.0.69.0/MoltenVK/macOS -framework MoltenVK

--- a/gameplay-editor/gameplay-editor.pro
+++ b/gameplay-editor/gameplay-editor.pro
@@ -4,6 +4,8 @@ TEMPLATE = app
 CONFIG += c++11
 CONFIG(debug, debug|release): DEFINES += _DEBUG
 
+DESTDIR = $$PWD/../build/bin
+
 SOURCES += \
     src/DockWidget.cpp \
     src/DockWidgetManager.cpp \
@@ -64,8 +66,8 @@ win32 {
     DEFINES += _WINDOWS WIN32
     DEFINES += VK_USE_PLATFORM_WIN32_KHR
     INCLUDEPATH += $$(VULKAN_SDK)/Include
-    CONFIG(debug, debug|release): LIBS += -L$$PWD/../build/gameplay/Debug/debug/ -lgameplay
-    CONFIG(release, debug|release): LIBS += -L$$PWD/../build/gameplay/Release/release/ -lgameplay
+    CONFIG(debug, debug|release): LIBS += -L$$PWD/../build/lib/ -lgameplay_d
+    CONFIG(release, debug|release): LIBS += -L$$PWD/../build/lib/ -lgameplay
     CONFIG(debug, debug|release): LIBS += -L$$PWD/../external-deps/lib/windows/x86_64/Debug/ -lgameplay-deps
     CONFIG(release, debug|release): LIBS += -L$$PWD/../external-deps/lib/windows/x86_64/Release/ -lgameplay-deps
     LIBS += -lkernel32 -luser32 -lgdi32 -lwinspool -lcomdlg32 -ladvapi32 -lshell32 -lole32 -loleaut32 -luuid -lodbc32 -lodbccp32 -limm32 -limagehlp -lversion -lwinmm -lxinput
@@ -79,6 +81,8 @@ win32 {
 }
 
 linux {
+    CONFIG(debug, debug|release): PRE_TARGETDEPS += $$PWD/../build/lib/libgameplay_d.a
+    CONFIG(release, debug|release):PRE_TARGETDEPS += $$PWD/../build/lib/libgameplay.a
     DEFINES += SDL_VIDEO_DRIVER_X11
     DEFINES += VK_USE_PLATFORM_XLIB_KHR
     QMAKE_CXXFLAGS += -lstdc++ -pthread -w
@@ -96,18 +100,18 @@ linux {
     INCLUDEPATH += /usr/include/libpng12
     INCLUDEPATH += /usr/include/harfbuzz
     INCLUDEPATH += $$(VULKAN_SDK)/include
-    CONFIG(debug, debug|release): LIBS += -L$$PWD/../build/gameplay/Debug/ -lgameplay
-    CONFIG(release, debug|release): LIBS += -L$$PWD/../build/gameplay/Release/ -lgameplay
+    CONFIG(debug, debug|release): LIBS += -L$$PWD/../build/lib/ -lgameplay_d
+    CONFIG(release, debug|release): LIBS += -L$$PWD/../build/lib/ -lgameplay
     LIBS += -L$$PWD/../external-deps/lib/linux/x86_64/ -lgameplay-deps
-    LIBS += -lrt -ldl -lX11 -lpthread -lgtk-x11-2.0 -lglib-2.0 -lgobject-2.0 -lxcb -lsndio
+    LIBS += -lrt -ldl -lX11 -lpthread -lglib-2.0 -lgobject-2.0 -lxcb -lsndio
     LIBS += -L$$(VULKAN_SDK)/lib/ -lvulkan
 }
 
 macx {
     DEFINES += VK_USE_PLATFORM_MACOS_MVK
     INCLUDEPATH += $$(HOME)/vulkansdk-macos-1.0.69.0/macOS/include
-    CONFIG(debug, debug|release): LIBS += -L$$PWD/../build/gameplay/Debug/ -lgameplay
-    CONFIG(release, debug|release):LIBS += -L$$PWD/../build/gameplay/Release/ -lgameplay
+    CCONFIG(debug, debug|release): LIBS += -L$$PWD/../build/lib/ -lgameplay_d
+    CONFIG(release, debug|release):LIBS += -L$$PWD/../build/lib/ -lgameplay
     LIBS += -L$$PWD/../external-deps/lib/macos/x86_64/ -lgameplay-deps
     LIBS += -L$$PWD/../external-deps/lib/macos/x86_64/ -lgameplay-deps
     LIBS += -L/usr/lib -liconv

--- a/gameplay/gameplay.pro
+++ b/gameplay/gameplay.pro
@@ -6,6 +6,9 @@ CONFIG += c++11
 CONFIG -= qt
 CONFIG(debug, debug|release): DEFINES += _DEBUG
 
+CONFIG(debug, debug|release): TARGET = gameplay_d
+DESTDIR = $$PWD/../build/lib
+
 SOURCES += \
     src/Activator.cpp \
     src/Animation.cpp \


### PR DESCRIPTION
4 changes for qtcreator project :
- output gameplay library to build/lib and binaries to build/bin
- gameplay library debug version append "_d"
- added gameplay-all.pro, a root subdir project that load all sub projects (it's easier to recompile all sub projects at once or see gameplay library changes when running gameplay-app)
- removed on linux build, link with -lgtk-x11-2.0 (useless for now)

when configuring long build paths, add this => build/%{CurrentProject:Name}/Debug